### PR TITLE
Infer kernel dimensions from data

### DIFF
--- a/R/infer_parameters.R
+++ b/R/infer_parameters.R
@@ -1,5 +1,12 @@
 infer_space_kernel_params <- function(data, plot = FALSE){
 
+  if (!"z_infer" %in% names(data)) {
+    stop("data must contain a 'z_infer' column", call. = FALSE)
+  }
+
+  n <- length(unique(data$id))
+  nt <- max(data$t)
+
   zmat <- matrix(data$z_infer, nrow = nt, ncol = n, byrow = FALSE)
 
   # Step 2: compute correlation between sites across time
@@ -46,6 +53,13 @@ infer_space_kernel_params <- function(data, plot = FALSE){
 }
 
 infer_time_kernel_params <- function(data, period, plot = FALSE){
+
+  if (!"z_infer" %in% names(data)) {
+    stop("data must contain a 'z_infer' column", call. = FALSE)
+  }
+
+  n <- length(unique(data$id))
+  nt <- max(data$t)
 
   fmat <- t(matrix(data$z_infer, nrow = nt, ncol = n, byrow = FALSE))
   cov_mat <- cov(fmat, use = "pairwise.complete.obs")

--- a/tests/testthat/test-infer-parameters.R
+++ b/tests/testthat/test-infer-parameters.R
@@ -1,0 +1,24 @@
+test_that("infer_space_kernel_params requires z_infer", {
+  data <- data.frame(id = 1, t = 1, lat = 0, lon = 0)
+  expect_error(infer_space_kernel_params(data), "z_infer")
+})
+
+test_that("infer_time_kernel_params requires z_infer", {
+  data <- data.frame(id = 1, t = 1, lat = 0, lon = 0)
+  expect_error(infer_time_kernel_params(data, period = 1), "z_infer")
+})
+
+test_that("infer parameter functions derive counts from data", {
+  set.seed(1)
+  data <- data.frame(
+    id = rep(1:2, each = 3),
+    t = rep(1:3, times = 2),
+    lon = rep(c(0, 1), each = 3),
+    lat = rep(c(0, 1), each = 3),
+    z_infer = rnorm(6)
+  )
+  space <- infer_space_kernel_params(data)
+  time <- infer_time_kernel_params(data, period = 3)
+  expect_named(space, "length_scale")
+  expect_named(time, c("periodic_scale", "long_term_scale", "period"))
+})


### PR DESCRIPTION
## Summary
- derive `n` and `nt` from input data in kernel parameter inference helpers
- validate presence of `z_infer` before computing kernels
- add tests for parameter inference helpers

## Testing
- `R -q -e 'devtools::document()'` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a433ed3a0c8326be766abe341acb16