### PR TITLE
Fix observed summary naming and streamline data ordering

### DIFF
--- a/R/data.R
+++ b/R/data.R
@@ -60,7 +60,7 @@ data_missing <- function(data, ...){
   return(data)
 }
 
-data_observed_summmary <- function(data, ...){
+data_observed_summary <- function(data, ...){
   site_names <- rlang::enquos(...)
 
   data <- data |>
@@ -120,9 +120,8 @@ data_process <- function(data, ...){
   data <- data |>
     data_complete(...) |>
     data_missing(...) |>
-    data_observed_summmary(...) |>
+    data_observed_summary(...) |>
     data_initial_par() |>
-    data_order_index() |>
     data_order_index(...)
 
   return(data)


### PR DESCRIPTION
## Summary
- rename `data_observed_summmary` to `data_observed_summary`
- simplify `data_process` ordering by removing redundant `data_order_index()`

## Testing
- `R -q -e 'devtools::document()'` *(fails: command not found)*
- `R -q -e 'devtools::test()'` *(fails: command not found)*
- `R -q -e 'devtools::check()'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a433e5279483269abb4f169f7579ac