### PR TITLE
Add configurable mu parameter to simulate_data

### DIFF
--- a/tests/testthat/test-simulate.R
+++ b/tests/testthat/test-simulate.R
@@ -1,0 +1,36 @@
+test_that("mu can be scalar or vector", {
+  n <- 3
+  nt <- 2
+  coordinates <- data.frame(
+    id = factor(1:n),
+    lat = 1:n,
+    lon = 1:n
+  )
+  space_k <- diag(n)
+  time_k <- diag(nt)
+
+  set.seed(123)
+  out_scalar <- simulate_data(
+    n = n, nt = nt,
+    coordinates = coordinates,
+    space_k = space_k, time_k = time_k,
+    mu = 1
+  )
+  expect_equal(unique(out_scalar$mu), rep(1, n))
+
+  mu_vec <- seq_len(n)
+  set.seed(123)
+  out_vec <- simulate_data(
+    n = n, nt = nt,
+    coordinates = coordinates,
+    space_k = space_k, time_k = time_k,
+    mu = mu_vec
+  )
+  expect_equal(unique(out_vec$mu), mu_vec)
+  expect_equal(out_vec$z, out_vec$mu + out_vec$f)
+
+  expect_error(
+    simulate_data(n, nt, coordinates, space_k, time_k, mu = 1:4),
+    "`mu` must have length 1 or `n`"
+  )
+})

--- a/vignettes/Introduction.Rmd
+++ b/vignettes/Introduction.Rmd
@@ -190,9 +190,10 @@ p_switch = 0.1
 coordinates <- data.frame(
   id = factor(1:n),
   lat = 1:n,
-  lon = 1:n,
-  mu = log(site_means)
+  lon = 1:n
 )
+
+mu <- log(site_means)
 
 space_k <- space_kernel(
   coordinates = coordinates,
@@ -211,7 +212,8 @@ true_data <- simulate_data(
   nt = nt,
   coordinates = coordinates,
   space_k = space_k,
-  time_k = time_k
+  time_k = time_k,
+  mu = mu
 )
 dplyr::glimpse(true_data)
 


### PR DESCRIPTION
## Summary
- allow `simulate_data()` to accept a scalar or vector `mu`
- validate `mu` length before computing the log-mean
- update vignette example and add tests for new argument

## Testing
- `R -q -e 'devtools::document()'` *(fails: command not found)*
- `R -q -e 'devtools::test()'` *(fails: command not found)*
- `R -q -e 'devtools::check()'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a4340579ec8326aded3975cf6d7ef0