### PR TITLE
Ensure lag zero in temporal correlations

### DIFF
--- a/R/infer_parameters.R
+++ b/R/infer_parameters.R
@@ -64,7 +64,7 @@ infer_time_kernel_params <- function(data, period, nt, n, plot = FALSE, max_pair
     mean_corr_by_lag[h + 1] <- mean(correlations, na.rm = TRUE)
   }
 
-  time_cor <- data.frame(time_distance = 1:nt, cor = mean_corr_by_lag)
+  time_cor <- data.frame(time_distance = lags, cor = mean_corr_by_lag)
 
   fit_sigma <- function(params, period, time_cor) {
     predicted_correlations <- periodic_kernel(x = time_cor$time_distance,
@@ -108,6 +108,7 @@ infer_time_kernel_params <- function(data, period, nt, n, plot = FALSE, max_pair
   list(
     periodic_scale = optim_result_time$par[1],
     long_term_scale = optim_result_time$par[2],
-    period = period
+    period = period,
+    time_cor = time_cor
   )
 }

--- a/tests/testthat/test-infer-parameters.R
+++ b/tests/testthat/test-infer-parameters.R
@@ -1,0 +1,8 @@
+test_that("first row of time_cor corresponds to lag 0", {
+  set.seed(123)
+  nt <- 5
+  n <- 3
+  data <- data.frame(z_infer = rnorm(nt * n))
+  res <- infer_time_kernel_params(data, period = 52, nt = nt, n = n, plot = FALSE)
+  expect_identical(res$time_cor$time_distance[1], 0)
+})


### PR DESCRIPTION
## Summary
- compute temporal correlation distances starting at lag 0
- expose `time_cor` and add regression test for lag 0

## Testing
- `R -q -e 'devtools::document()'` *(fails: command not found: R)*
- `R -q -e 'devtools::test()'` *(fails: command not found: R)*
- `R -q -e 'devtools::check()'` *(fails: command not found: R)*

------
https://chatgpt.com/codex/tasks/task_e_68baf9648dcc8326bd9dd2e9f3086413