### PR TITLE
Store observation identifiers in state

### DIFF
--- a/R/posterior.R
+++ b/R/posterior.R
@@ -120,8 +120,8 @@ bounds <- function(state, n_lambda = 30, n_draw = 100,
 
   # Build output
   out <- data.frame(
-    id = obs_data$id,
-    t = obs_data$t,
+    id = state$id,
+    t = state$t,
     qs
   )
 

--- a/R/state.R
+++ b/R/state.R
@@ -78,6 +78,8 @@ gp_build_state <- function(obs_data, coordinates, hyperparameters, n, nt, period
     kdiag_full = kdiag_full,
     A_solve = A_solve,
     mu_infer = obs_data$mu_infer,
+    id = obs_data$id,
+    t = obs_data$t,
     N = N,
     n = n,
     nt = nt

--- a/tests/testthat/test-posterior.R
+++ b/tests/testthat/test-posterior.R
@@ -1,0 +1,34 @@
+test_that("bounds returns quantiles for minimal state", {
+  set.seed(123)
+
+  obs_data <- data.frame(
+    id = 1L,
+    t = 1L,
+    y_obs = 0,
+    f_infer = 0,
+    mu_infer = 0
+  )
+
+  coordinates <- data.frame(
+    id = 1L,
+    lon = 0,
+    lat = 0
+  )
+
+  state <- gp_build_state(
+    obs_data = obs_data,
+    coordinates = coordinates,
+    hyperparameters = c(1, 1, 1),
+    n = 1,
+    nt = 1,
+    period = 52
+  )
+
+  result <- bounds(state, n_lambda = 2, n_draw = 2, quantiles = c(0.5))
+
+  expect_s3_class(result, "data.frame")
+  expect_equal(nrow(result), 1)
+  expect_named(result, c("id", "t", "q0.5"))
+  expect_equal(result$id, obs_data$id)
+  expect_equal(result$t, obs_data$t)
+})


### PR DESCRIPTION
## Summary
- add observation identifiers to the gp state object so callers can access them
- update bounds() to read identifiers from the state instead of an undefined data frame
- add a regression test that ensures bounds() succeeds on a minimal state object

## Testing
- Rscript -e "testthat::test_dir('tests/testthat')" *(fails: `Rscript` not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d144d65914832684bed49ca4d5c08e