### PR TITLE
Clarify fit and state documentation intros

### DIFF
--- a/R/fit_hyperparameters.R
+++ b/R/fit_hyperparameters.R
@@ -1,4 +1,13 @@
-#' Fit hyperparmeters
+#' Fit hyperparameters
+#'
+#' This helper picks a small group of monitoring sites, hides a few of their
+#' observed counts, and tweaks the model settings until those withheld values
+#' are predicted well.
+#'
+#' Under the hood it samples `n_sites` IDs, masks a proportion of their observed
+#' counts, and uses `optim()` with an L-BFGS-B search to maximise the Poisson
+#' log-likelihood of the held-out data, returning the hyperparameters that score
+#' best.
 #' @export
 fit <- function(obs_data, nt, period, n_sites, mask_prop = 0.2, verbose = FALSE, par0 = c(1, 5, 100), lower = c(1e-4, 0.8, 52 * 1.5), upper = c(2, 10, 500)) {
   ids <- sample(unique(obs_data$id), n_sites)

--- a/R/state.R
+++ b/R/state.R
@@ -15,6 +15,14 @@ kdiag_from_factors <- function(space_diag, time_diag, n, nt) {
 
 #' Build state object
 #'
+#' This convenience wrapper assembles the ingredients the Gaussian process (GP)
+#' model needs so downstream functions can work with a single, tidy bundle.
+#'
+#' It builds the spatial and temporal kernels, indexes the observed counts,
+#' prepares working responses and variances for the Poisson log-scale
+#' approximation, and returns the matrices and closures required for GP
+#' inference.
+#'
 #' @param obs_data Observation data
 #' @param coordinates Site coordinates
 #' @param hyperparameters Vector of hyperparameters


### PR DESCRIPTION
## Summary
- add plain-language introductions to the `fit()` and `gp_build_state()` roxygen headers
- align terminology in the state documentation with existing Gaussian process wording

## Testing
- `Rscript -e "devtools::document()"` *(fails: `Rscript` not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d144ecca208326bfe86b07b32d70db