### PR TITLE
Require coordinates when fitting hyperparameters

### DIFF
--- a/R/fit_hyperparameters.R
+++ b/R/fit_hyperparameters.R
@@ -1,9 +1,38 @@
 #' Fit hyperparmeters
+#'
+#' @param obs_data Data frame of observations with at least `id`, `y_obs`,
+#'   `mu_infer`, and `f_infer` columns.
+#' @param coordinates Data frame of site coordinates containing an `id` column
+#'   that matches the site identifiers in `obs_data`.
+#' @param nt Number of time points per site.
+#' @param period Period used for the temporal kernel.
+#' @param n_sites Number of sites to sample for optimisation.
+#' @param mask_prop Proportion of observed points per site to hold out.
+#' @param verbose Logical; whether to print objective values during
+#'   optimisation.
+#' @param par0 Initial hyperparameter values passed to `optim()`.
+#' @param lower Lower bounds for the hyperparameters passed to `optim()`.
+#' @param upper Upper bounds for the hyperparameters passed to `optim()`.
+#'
+#' @return A list as returned by `stats::optim()`.
 #' @export
-fit <- function(obs_data, nt, period, n_sites, mask_prop = 0.2, verbose = FALSE, par0 = c(1, 5, 100), lower = c(1e-4, 0.8, 52 * 1.5), upper = c(2, 10, 500)) {
+fit <- function(obs_data, coordinates, nt, period, n_sites, mask_prop = 0.2, verbose = FALSE, par0 = c(1, 5, 100), lower = c(1e-4, 0.8, 52 * 1.5), upper = c(2, 10, 500)) {
+  if (!"id" %in% names(coordinates)) {
+    stop("`coordinates` must contain an `id` column.", call. = FALSE)
+  }
+
   ids <- sample(unique(obs_data$id), n_sites)
-  fitting_data   <- obs_data[obs_data$id %in% ids, ]
-  fitting_coords <- coordinates[coordinates$id %in% ids, ]
+  missing_ids <- setdiff(ids, coordinates$id)
+  if (length(missing_ids)) {
+    stop(
+      "Coordinates missing for sampled site IDs: ",
+      paste(missing_ids, collapse = ", "),
+      call. = FALSE
+    )
+  }
+
+  fitting_data <- obs_data[obs_data$id %in% ids, ]
+  fitting_coords <- coordinates[match(ids, coordinates$id), , drop = FALSE]
 
   # Hold-out mask: choose a fraction of NON-NA y_obs per site; keep at least 1 observed point/site
   split_idx <- split(seq_len(nrow(fitting_data)), fitting_data$id)

--- a/man/fit.Rd
+++ b/man/fit.Rd
@@ -6,6 +6,7 @@
 \usage{
 fit(
   obs_data,
+  coordinates,
   nt,
   period,
   n_sites,
@@ -15,6 +16,32 @@ fit(
   lower = c(1e-04, 0.8, 52 * 1.5),
   upper = c(2, 10, 500)
 )
+}
+\arguments{
+\item{obs_data}{Data frame of observations with at least \code{id}, \code{y_obs},
+\code{mu_infer}, and \code{f_infer} columns.}
+
+\item{coordinates}{Data frame of site coordinates containing an \code{id} column
+that matches the site identifiers in \code{obs_data}.}
+
+\item{nt}{Number of time points per site.}
+
+\item{period}{Period used for the temporal kernel.}
+
+\item{n_sites}{Number of sites to sample for optimisation.}
+
+\item{mask_prop}{Proportion of observed points per site to hold out.}
+
+\item{verbose}{Logical; whether to print objective values during optimisation.}
+
+\item{par0}{Initial hyperparameter values passed to \code{optim()}.}
+
+\item{lower}{Lower bounds for the hyperparameters passed to \code{optim()}.}
+
+\item{upper}{Upper bounds for the hyperparameters passed to \code{optim()}.}
+}
+\value{
+A list as returned by \code{stats::optim()}.
 }
 \description{
 Fit hyperparmeters

--- a/tests/testthat/test-hyperparameter_cv.R
+++ b/tests/testthat/test-hyperparameter_cv.R
@@ -46,3 +46,37 @@ test_that("tune_hyperparameters_optim returns list of results", {
   expect_true(is.finite(res$best_cv_score))
 })
 
+test_that("fit requires coordinates for sampled sites", {
+  set.seed(2)
+  n_sites <- 3
+  nt <- 4
+  ids <- rep(seq_len(n_sites), each = nt)
+  t <- rep(seq_len(nt), times = n_sites)
+  y <- rpois(n_sites * nt, lambda = 1)
+  mu <- rep(0, n_sites * nt)
+  f <- log1p(y) - mu
+  obs_data <- data.frame(id = ids, t = t, y_obs = y, mu_infer = mu, f_infer = f)
+  coordinates <- data.frame(id = seq_len(n_sites), lon = rnorm(n_sites), lat = rnorm(n_sites))
+
+  res <- fit(
+    obs_data = obs_data,
+    coordinates = coordinates,
+    nt = nt,
+    period = 52,
+    n_sites = 2
+  )
+  expect_true(all(c("par", "value", "counts", "convergence", "message") %in% names(res)))
+
+  missing_coords <- coordinates[-1, , drop = FALSE]
+  expect_error(
+    fit(
+      obs_data = obs_data,
+      coordinates = missing_coords,
+      nt = nt,
+      period = 52,
+      n_sites = n_sites
+    ),
+    "Coordinates missing"
+  )
+})
+


### PR DESCRIPTION
## Summary
- add an explicit `coordinates` argument to `fit()` and validate that sampled site IDs are present
- update documentation and tests to reflect the new signature and guard against missing coordinates

## Testing
- `Rscript -e "devtools::document()"` *(fails: Rscript not available in container)*
- `Rscript -e "devtools::test()"` *(fails: Rscript not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d144c77fec8326ba12386bf7b754bc