### PR TITLE
Parallelise the posterior draws with the future framework

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -10,3 +10,5 @@ implementation/
 ^doc$
 ^Meta$
 ^codecov\.yml$
+^\.claude$
+^AGENTS\.md$

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,6 +20,8 @@ Depends:
     R (>= 4.1.0)
 Imports:
     dplyr (>= 1.1.0),
+    future,
+    future.apply,
     rlang,
     tidyr
 Suggests: 

--- a/R/cg.R
+++ b/R/cg.R
@@ -8,7 +8,9 @@
 #'
 #' @param v Numeric vector of length `nrow(space) * nrow(time)`, ordered with
 #'   times varying fastest within site.
-#' @param space Spatial kernel matrix (size \eqn{n \times n}).
+#' @param space Spatial kernel matrix (size \eqn{n \times n}). Must be
+#'   symmetric (kernels are, by construction) -- the implementation relies on
+#'   `t(space) == space`.
 #' @param time Temporal kernel matrix (size \eqn{nt \times nt}).
 #'
 #' @return A numeric vector the same length as `v`.
@@ -16,9 +18,11 @@ kron_mv <- function(v, space, time) {
   # We want vec(t(Y)) where Y = space %*% X %*% t(time) and X = sites × times.
   # Since matrix(v, n_times, n_sites) is already t(X), and
   #   t(Y) = time %*% t(X) %*% t(space),
-  # we can compute the result with NO length-N transposes (only the tiny t(space)):
+  # we can compute the result with NO transposes at all: `space` is a
+  # symmetric kernel, so t(space) = space and the n x n copy t() would
+  # otherwise allocate every CG iteration is avoided.
   Xt <- matrix(v, nrow = nrow(time), ncol = nrow(space))  # = t(X)
-  as.vector(time %*% Xt %*% t(space))
+  as.vector(time %*% Xt %*% space)
 }
 
 #' Fill observed values into a full vector

--- a/R/predict.R
+++ b/R/predict.R
@@ -40,6 +40,13 @@
 #' Monte-Carlo would need hundreds of draws to match, and cells far from any
 #' gap are essentially exact.
 #'
+#' The draws are independent, so they run through
+#' [future.apply::future_lapply()]: serial under the default
+#' [future::plan()], parallel when the caller selects a multi-worker plan.
+#' `future.seed = TRUE` gives every draw its own pre-generated
+#' L'Ecuyer-CMRG stream, so results are reproducible under [set.seed()] and
+#' identical for every backend and worker count.
+#'
 #' @param obs_idx Integer indices of observed cells in the full vector.
 #' @param N Total number of cells (`n * nt`).
 #' @param space_mat Spatial kernel matrix (variance-scaled).
@@ -49,7 +56,8 @@
 #' @param n_draws Number of paired draws for the missing-data correction.
 #' @param tol CG tolerance for the draw solves.
 #' @param progress_bar Optional progress bar (from [make_curve_bar()]); ticked
-#'   once per draw.
+#'   once per draw. Only effective under a single-worker plan (parallel
+#'   workers cannot tick a bar in the calling session).
 #'
 #' @return Numeric vector of length `N`: the posterior variance of the field.
 gp_posterior_var <- function(obs_idx, N, space_mat, time_mat, noise_var,
@@ -59,34 +67,44 @@ gp_posterior_var <- function(obs_idx, N, space_mat, time_mat, noise_var,
   nt <- nrow(time_mat)
   eig_s <- eig_sym(space_mat)
   eig_t <- eig_sym(time_mat)
+  Us <- eig_s$vectors
+  Ut <- eig_t$vectors
+  UsT <- t(Us)
+  sqrt_nv <- sqrt(noise_var)
   d_eig <- outer(eig_t$values, eig_s$values) # nt x n eigenvalues of K
   shrink <- d_eig / (d_eig + noise_var)
 
   # exact complete-grid posterior variance: diag(K - K (K + nu I)^{-1} K),
   # per cell (time b, site a) = sum_ij Ut[b,j]^2 Us[a,i]^2 * d_ij nu / (d_ij + nu)
-  v_complete <- as.vector(
-    (eig_t$vectors^2) %*% (noise_var * shrink) %*% t(eig_s$vectors^2)
-  )
+  v_complete <- as.vector((Ut^2) %*% (noise_var * shrink) %*% t(Us^2))
 
-  ss_corr <- numeric(N)
-  for (i in seq_len(n_draws)) {
+  one_draw <- function(k) {
     # zero-mean perturbation draw conditioned on the observed cells:
     #   u ~ N(0, K);  e ~ N(0, nu I);  d = u - K S^T (S K S^T + nu I)^{-1} (Su + Se)
     u <- quick_mvnorm_chol(Rs_chol, Rt_chol)
-    e <- stats::rnorm(N, sd = sqrt(noise_var))
+    e <- stats::rnorm(N, sd = sqrt_nv)
     alpha <- cg(u[obs_idx] + e[obs_idx], obs_idx, N, space_mat, time_mat,
                 noise_var, tol = tol)
     d_obs <- u - kron_mv(fill_vector(alpha, obs_idx, N), space_mat, time_mat)
 
     # its complete-grid twin, exact in the eigenbasis, sharing the same u and e
     w <- matrix(u + e, nrow = nt, ncol = n)
-    coef <- crossprod(eig_t$vectors, w) %*% eig_s$vectors
-    d_complete <- u -
-      as.vector(eig_t$vectors %*% (coef * shrink) %*% t(eig_s$vectors))
+    coef <- crossprod(Ut, w) %*% Us
+    d_complete <- u - as.vector(Ut %*% (coef * shrink) %*% UsT)
 
-    ss_corr <- ss_corr + (d_obs^2 - d_complete^2)
     if (!is.null(progress_bar)) progress_bar$tick()
+    d_obs^2 - d_complete^2
   }
+
+  # future.seed = TRUE: one CMRG stream per draw, so output is reproducible
+  # under set.seed() and identical for every plan/worker count.
+  # future.stdout = NA: don't sink stdout, so the (sequential-only) progress
+  # bar renders live rather than after the last draw.
+  contrib <- future.apply::future_lapply(
+    seq_len(n_draws), one_draw,
+    future.seed = TRUE, future.stdout = NA
+  )
+  ss_corr <- Reduce(`+`, contrib)
   pmax(v_complete + ss_corr / n_draws, 0)
 }
 
@@ -143,7 +161,32 @@ gp_posterior_var <- function(obs_idx, N, space_mat, time_mat, noise_var,
 #' @param progress Logical; show a progress bar over the posterior-draw loop
 #'   (the expensive part). Defaults to `TRUE`, but the bar is drawn only in an
 #'   interactive UTF-8 / truecolor terminal -- it stays silent in scripts,
-#'   knitr, logs and CI. Set `FALSE` to disable it entirely.
+#'   knitr, logs and CI. Under a multi-worker [future::plan()] the bar is
+#'   suppressed (workers cannot tick it). Set `FALSE` to disable it entirely.
+#'
+#' @section Parallel execution:
+#' The `n_draws` perturbation draws are independent CG solves and run through
+#' the future framework. By default (no [future::plan()] set) they run
+#' serially, exactly as before. To spread them across CPU cores, set a plan
+#' before calling and reset it after:
+#'
+#' ```r
+#' future::plan(future::multisession, workers = 4)
+#' pred <- gp_predict(...)
+#' future::plan(future::sequential)
+#' ```
+#'
+#' Results are identical for every backend and worker count, and reproducible
+#' under [set.seed()] (each draw gets its own pre-generated L'Ecuyer-CMRG
+#' stream). Parallelism pays off when `n * n_draws` is large: each worker
+#' costs about a second to start and receives the kernel matrices once. For
+#' very large site counts you may need to raise
+#' `options(future.globals.maxSize = ...)` (the matrices shipped to workers
+#' are ~40 MB at 1000 sites x 260 weeks; the default cap is 500 MiB). If R
+#' uses a multithreaded BLAS (e.g. OpenBLAS/MKL), cap its threads inside
+#' workers to avoid oversubscription; R's shipped BLAS is single-threaded, so
+#' by default there is nothing to do. See
+#' `vignette("parallel", package = "weave")` for a walkthrough.
 #'
 #' @return A data frame with one row per cell and columns `id`, `t`, `rate`
 #'   (posterior point estimate of \eqn{\lambda}), and -- when `n_draws >= 1` --
@@ -268,7 +311,9 @@ gp_predict <- function(
 
   if (n_draws >= 1) {
     # --- posterior VARIANCE of the log-rate: exact part + draw correction ----
-    show_bar <- isTRUE(progress) && ansi_tty()
+    # The bar only makes sense under a single-worker plan: sequential futures
+    # run in this process (the tick closure fires), parallel workers do not.
+    show_bar <- isTRUE(progress) && ansi_tty() && future::nbrOfWorkers() == 1L
     pb <- if (show_bar) make_curve_bar(total = n_draws) else NULL
     vstd <- gp_posterior_var(
       obs_idx,

--- a/R/sample.R
+++ b/R/sample.R
@@ -49,7 +49,7 @@ quick_mvnorm_chol <- function(space_chol, time_chol) {
   # Apply separable transforms. vec(Z) has covariance (time ⊗ space); the
   # transpose-flatten below reorders to times-fastest, giving covariance
   # (space ⊗ time) to match kronecker(space, time).
-  Z <- t(space_chol) %*% W %*% time_chol
+  Z <- crossprod(space_chol, W) %*% time_chol
 
   # Flatten with times varying fastest
   as.vector(t(Z))

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -18,3 +18,4 @@ articles:
   contents:
   - gaussian-processes
   - walkthrough
+  - parallel

--- a/implementation/walkthrough.R
+++ b/implementation/walkthrough.R
@@ -118,6 +118,11 @@ p_one <- 0.1 # missingness controls (see observed_data)
 p_switch <- 0.05
 plot_sites <- 1:min(n, 100) # sites shown in the per-site panels (default: all; set e.g. 1:12 to subset)
 
+n_workers <- 1 # >1 parallelises gp_predict's posterior draws across background
+# R sessions (results are identical for any value, and reproducible under the
+# seed above). NOTE: workers load the INSTALLED weave, not this session's
+# load_all() copy -- run devtools::install() first when setting n_workers > 1.
+
 
 # -----------------------------------------------------------------------------
 # 2. Simulate ground truth
@@ -360,7 +365,16 @@ print("")
 #
 # Cost scales steeply with the number of sites (each draw is a full CG solve);
 # reduce `n` at the top of the script or `n_draws` here to experiment quickly.
+#
+# The draws parallelise via future::plan(), controlled by `n_workers` in the
+# Controls block: results are identical for every n_workers, and the braille
+# progress bar shows only when running serially (workers can't tick it).
 # -----------------------------------------------------------------------------
+if (n_workers > 1) {
+  future::plan(future::multisession, workers = n_workers)
+} else {
+  future::plan(future::sequential)
+}
 pred <- gp_predict(
   obs_data,
   coordinates,
@@ -369,6 +383,7 @@ pred <- gp_predict(
   period = period,
   n_draws = 100
 )
+future::plan(future::sequential) # back to serial for the rest of the session
 pred_df <- transform(pred, id = as.integer(id))
 cat(sprintf(
   "Dispersion r used for the interval (estimated) = %.1f  (true = %.1f)\n",

--- a/man/gp_posterior_var.Rd
+++ b/man/gp_posterior_var.Rd
@@ -35,7 +35,8 @@ gp_posterior_var(
 \item{tol}{CG tolerance for the draw solves.}
 
 \item{progress_bar}{Optional progress bar (from [make_curve_bar()]); ticked
-once per draw.}
+once per draw. Only effective under a single-worker plan (parallel
+workers cannot tick a bar in the calling session).}
 }
 \value{
 Numeric vector of length `N`: the posterior variance of the field.
@@ -59,4 +60,11 @@ numbers \eqn{u, e}, so their difference is nearly noise-free away from gaps
 (a control variate). Modest draw counts therefore give variances that plain
 Monte-Carlo would need hundreds of draws to match, and cells far from any
 gap are essentially exact.
+
+The draws are independent, so they run through
+[future.apply::future_lapply()]: serial under the default
+[future::plan()], parallel when the caller selects a multi-worker plan.
+`future.seed = TRUE` gives every draw its own pre-generated
+L'Ecuyer-CMRG stream, so results are reproducible under [set.seed()] and
+identical for every backend and worker count.
 }

--- a/man/gp_predict.Rd
+++ b/man/gp_predict.Rd
@@ -65,7 +65,8 @@ while the draw loop needs roughly half the CG iterations.}
 \item{progress}{Logical; show a progress bar over the posterior-draw loop
 (the expensive part). Defaults to `TRUE`, but the bar is drawn only in an
 interactive UTF-8 / truecolor terminal -- it stays silent in scripts,
-knitr, logs and CI. Set `FALSE` to disable it entirely.}
+knitr, logs and CI. Under a multi-worker [future::plan()] the bar is
+suppressed (workers cannot tick it). Set `FALSE` to disable it entirely.}
 }
 \value{
 A data frame with one row per cell and columns `id`, `t`, `rate`
@@ -91,6 +92,32 @@ Because the fit conditions on the observed set, missing cells are filled by
 genuine GP interpolation and their prediction interval can widen over gaps --
 unlike a completed-grid smoother that mean-imputes the gaps.
 }
+\section{Parallel execution}{
+
+The `n_draws` perturbation draws are independent CG solves and run through
+the future framework. By default (no [future::plan()] set) they run
+serially, exactly as before. To spread them across CPU cores, set a plan
+before calling and reset it after:
+
+```r
+future::plan(future::multisession, workers = 4)
+pred <- gp_predict(...)
+future::plan(future::sequential)
+```
+
+Results are identical for every backend and worker count, and reproducible
+under [set.seed()] (each draw gets its own pre-generated L'Ecuyer-CMRG
+stream). Parallelism pays off when `n * n_draws` is large: each worker
+costs about a second to start and receives the kernel matrices once. For
+very large site counts you may need to raise
+`options(future.globals.maxSize = ...)` (the matrices shipped to workers
+are ~40 MB at 1000 sites x 260 weeks; the default cap is 500 MiB). If R
+uses a multithreaded BLAS (e.g. OpenBLAS/MKL), cap its threads inside
+workers to avoid oversubscription; R's shipped BLAS is single-threaded, so
+by default there is nothing to do. See
+`vignette("parallel", package = "weave")` for a walkthrough.
+}
+
 \seealso{
 [infer_kernel_params()]
 }

--- a/man/kron_mv.Rd
+++ b/man/kron_mv.Rd
@@ -10,7 +10,9 @@ kron_mv(v, space, time)
 \item{v}{Numeric vector of length `nrow(space) * nrow(time)`, ordered with
 times varying fastest within site.}
 
-\item{space}{Spatial kernel matrix (size \eqn{n \times n}).}
+\item{space}{Spatial kernel matrix (size \eqn{n \times n}). Must be
+symmetric (kernels are, by construction) -- the implementation relies on
+`t(space) == space`.}
 
 \item{time}{Temporal kernel matrix (size \eqn{nt \times nt}).}
 }

--- a/tests/testthat/test-predict.R
+++ b/tests/testthat/test-predict.R
@@ -102,6 +102,89 @@ test_that("make_curve_bar draws a braille wave and tracks progress", {
 })
 
 
+test_that("gp_predict draws are reproducible under set.seed", {
+  old <- future::plan(future::sequential)
+  on.exit(future::plan(old), add = TRUE)
+  n <- 4; nt <- 6; period <- 52
+  coords <- data.frame(id = factor(1:n), lon = runif(n), lat = runif(n))
+  obs <- make_obs(n, nt, missing = c(3, 10, 15))
+
+  set.seed(11)
+  a <- gp_predict(obs, coords, hp_fixed, nt = nt, period = period,
+                  n_draws = 10, progress = FALSE)
+  set.seed(11)
+  b <- gp_predict(obs, coords, hp_fixed, nt = nt, period = period,
+                  n_draws = 10, progress = FALSE)
+  set.seed(12)
+  c <- gp_predict(obs, coords, hp_fixed, nt = nt, period = period,
+                  n_draws = 10, progress = FALSE)
+
+  expect_identical(a$lower, b$lower)
+  expect_identical(a$upper, b$upper)
+  expect_false(isTRUE(all.equal(a$lower, c$lower)))
+})
+
+
+test_that("gp_predict results are invariant to the future backend", {
+  skip_on_cran()
+  old <- future::plan(future::sequential)
+  on.exit(future::plan(old), add = TRUE)
+  n <- 4; nt <- 6; period <- 52
+  coords <- data.frame(id = factor(1:n), lon = runif(n), lat = runif(n))
+  obs <- make_obs(n, nt, missing = c(3, 10, 15))
+
+  set.seed(21)
+  res_seq <- gp_predict(obs, coords, hp_fixed, nt = nt, period = period,
+                        n_draws = 8, progress = FALSE)
+
+  # multisession workers load the INSTALLED weave; skip (rather than fail)
+  # when running from load_all() without an installed copy.
+  res_par <- tryCatch({
+    future::plan(future::multisession, workers = 2)
+    set.seed(21)
+    gp_predict(obs, coords, hp_fixed, nt = nt, period = period,
+               n_draws = 8, progress = FALSE)
+  }, error = function(e) {
+    skip(paste("multisession workers unavailable:", conditionMessage(e)))
+  })
+
+  expect_equal(res_seq$lower, res_par$lower)
+  expect_equal(res_seq$upper, res_par$upper)
+  expect_equal(res_seq$rate, res_par$rate)
+})
+
+
+test_that("gp_predict suppresses the progress bar under a parallel plan", {
+  skip_on_cran()
+  old <- future::plan(future::sequential)
+  on.exit(future::plan(old), add = TRUE)
+  n <- 4; nt <- 6; period <- 52
+  coords <- data.frame(id = factor(1:n), lon = runif(n), lat = runif(n))
+  obs <- make_obs(n, nt, missing = c(3, 10, 15))
+
+  set.seed(31)
+  quiet <- gp_predict(obs, coords, hp_fixed, nt = nt, period = period,
+                      n_draws = 3, progress = FALSE)
+
+  testthat::local_mocked_bindings(ansi_tty = function() TRUE)
+  bar <- tryCatch({
+    future::plan(future::multisession, workers = 2)
+    set.seed(31)
+    utils::capture.output(
+      loud <- gp_predict(obs, coords, hp_fixed, nt = nt, period = period,
+                         n_draws = 3, progress = TRUE)
+    )
+  }, error = function(e) {
+    skip(paste("multisession workers unavailable:", conditionMessage(e)))
+  })
+
+  # no braille wave emitted, and the numbers are unchanged
+  expect_false(grepl("[⠀-⣿]", paste(bar, collapse = "")))
+  expect_equal(loud$lower, quiet$lower)
+  expect_equal(loud$upper, quiet$upper)
+})
+
+
 test_that("gp_predict models real t spacing, not the row index", {
   n <- 3; nt <- 5; period <- 4
   set.seed(1)

--- a/vignettes/parallel.Rmd
+++ b/vignettes/parallel.Rmd
@@ -1,0 +1,70 @@
+---
+title: "Running predictions in parallel"
+output:
+  rmarkdown::html_vignette:
+    css: weave.css
+vignette: >
+  %\VignetteIndexEntry{Running predictions in parallel}
+  %\VignetteEncoding{UTF-8}
+  %\VignetteEngine{knitr::rmarkdown}
+editor_options:
+  markdown:
+    wrap: 72
+---
+
+```{r, include = FALSE}
+source("_common.R")
+```
+
+The expensive part of `gp_predict()` is the set of `n_draws` perturbation
+draws that estimate how the missing weeks widen the prediction interval. Each
+draw is an independent conjugate-gradient solve, so at scale (many sites,
+many draws) they parallelise naturally across CPU cores.
+
+weave uses the [future](https://future.futureverse.org/) framework for this.
+By default everything runs serially — nothing to install, nothing to
+configure — and you opt in with a single line before the call. No arguments
+to `gp_predict()` change.
+
+```{r parallel, eval = FALSE}
+future::plan(future::multisession, workers = 4)   # 4 background R sessions
+
+pred <- gp_predict(obs_data, coordinates, hyperparameters = est,
+                   nt = nt, period = period, n_draws = 100)
+
+future::plan(future::sequential)                  # back to serial
+```
+
+`future::multisession` works on every platform (it uses background R
+sessions, not forks). Any other future backend — `multicore` on Linux/macOS,
+a cluster of machines — works the same way; see the
+[future documentation](https://future.futureverse.org/) for the options.
+
+## The numbers never change
+
+Parallelism is purely a speed decision:
+
+* **Results are identical** for every backend and worker count. Each draw
+  gets its own pre-generated random-number stream, so the split across
+  workers cannot affect the numbers.
+* **Reproducibility** works exactly as in serial code: `set.seed(1)` before
+  `gp_predict()` gives the same answer whether you run on 1 worker or 8.
+
+## When it pays off
+
+Each worker takes about a second to start, and receives the kernel matrices
+once. Parallelism therefore helps when `sites × draws` is large; for small
+problems the serial default is already the fastest option. As an indication:
+a 300-site × 260-week problem with 10% missing data and 100 draws ran about
+4× faster with `workers = 4` on a 4-performance-core laptop.
+
+## Practicalities
+
+* The **progress bar** only shows when running serially — background workers
+  cannot draw it.
+* At very large site counts you may need to raise the future framework's
+  export cap: `options(future.globals.maxSize = 1e9)` (the matrices shipped
+  to each worker are about 40 MB at 1000 sites × 260 weeks).
+* If your R uses a **multithreaded BLAS** (OpenBLAS, MKL), cap its threads
+  inside workers to avoid oversubscription. R's shipped BLAS is
+  single-threaded, so by default there is nothing to do.

--- a/vignettes/walkthrough.Rmd
+++ b/vignettes/walkthrough.Rmd
@@ -499,6 +499,11 @@ ggplot() +
   theme_weave()
 ```
 
+At scale, the draws behind the interval can run across CPU cores: see the
+short companion article
+[*Running predictions in parallel*](parallel.html) — one line of setup, and
+the numbers are guaranteed not to change.
+
 ### Did we fill the gaps well?
 
 The honest test is the **held-out** weeks: does the 95% interval contain the


### PR DESCRIPTION
## What

The `n_draws` perturbation draws in `gp_posterior_var()` — the dominant cost of `gp_predict()` — are independent CG solves. They now run through `future.apply::future_lapply()`, so parallelism is a one-line, user-side opt-in:

```r
future::plan(future::multisession, workers = 4)
pred <- gp_predict(...)
future::plan(future::sequential)
```

No arguments to `gp_predict()` change and there is no internal cluster management; the package is backend-agnostic.

## Design

- **RNG**: `future.seed = TRUE` gives each draw its own pre-generated L''Ecuyer-CMRG stream, so results are reproducible under `set.seed()` and **bit-identical for every backend, worker count and chunking** (verified empirically). Serial `lower`/`upper` change once relative to the previous RNG path; the deterministic `rate` is byte-identical.
- **Progress bar**: the braille curve bar still renders live under the default sequential plan (`future.stdout = NA` avoids future''s stdout capture); it is suppressed under multi-worker plans, where workers cannot tick it. `progressr` was considered and rejected to keep the dependency footprint light.
- **Hygiene**: `kron_mv()` exploits kernel symmetry to drop an n x n transpose allocation per CG iteration; `quick_mvnorm_chol()` uses `crossprod()`; loop-invariant eigenvector transposes hoisted out of the draw loop.

## Docs

New short vignette *Running predictions in parallel* (registered on pkgdown), pointers from the walkthrough vignette and a `@section Parallel execution` in `?gp_predict`, and an `n_workers` control in `implementation/walkthrough.R`.

## Verification

- `devtools::test()`: 99 pass, 0 fail (the multisession tests run against an installed copy)
- sequential vs `multisession(2)`/`multisession(4)`: outputs **identical**
- vs previous HEAD: `rate` byte-identical; interval widths within 0.4% (Monte-Carlo jitter at 100 draws)
- Benchmark (n = 300 sites, nt = 260, 10% missing, 100 draws): **326 s -> 77 s** with 4 workers (~1 s worker start-up)
- `covr`: 98.94% (predict.R at 100%)
- `R CMD check`: 0 errors, 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)