### PR TITLE
Documentation overhaul: four-dimension review, new vignettes, roxygen markdown

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: weave
 Type: Package
-Title: Health facility malaria data interpolation
+Title: Health Facility Malaria Data Interpolation
 Version: 0.1.5
 Authors@R: c(
     person("Pete", "Winskill", email = "p.winskill@imperial.ac.uk", role = c("aut", "cre")),
@@ -9,12 +9,13 @@ Authors@R: c(
 Description: Interpolates routine health-facility malaria counts over space and
     time with a separable Gaussian process. Provides fast, deterministic
     kernel-hyperparameter estimation by exact marginal likelihood and
-    matrix-free prediction (with count prediction intervals) by preconditioned
-    conjugate gradient, conditioning on observed cells so gaps are filled by
+    matrix-free prediction (with count prediction intervals) by conjugate
+    gradient, conditioning on observed cells so gaps are filled by
     genuine interpolation.
 License: MIT + file LICENSE
 Encoding: UTF-8
 LazyData: true
+Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.3.3
 Depends:
     R (>= 4.1.0)

--- a/R/cg.R
+++ b/R/cg.R
@@ -1,7 +1,8 @@
-#' Fast Kronecker–product matrix–vector multiply (times vary fastest)
+#' Fast Kronecker-product matrix-vector multiply (times vary fastest)
 #'
-#' In plain terms: multiplies a big covariance `K = space ⊗ time` by a vector
-#' without ever forming `K`, using a reshape–multiply–reshape trick.
+#' In plain terms: multiplies a big covariance
+#' \eqn{K = \mathrm{space} \otimes \mathrm{time}} by a vector without ever
+#' forming `K`, using a reshape-multiply-reshape trick.
 #'
 #' Technically: for \eqn{v = \mathrm{vec}(X^\top)} with `times` varying fastest,
 #' computes \eqn{(space \otimes time)\,v = \mathrm{vec}\!\big((space\,X\,time^\top)^\top\big)}.
@@ -14,6 +15,7 @@
 #' @param time Temporal kernel matrix (size \eqn{nt \times nt}).
 #'
 #' @return A numeric vector the same length as `v`.
+#' @keywords internal
 kron_mv <- function(v, space, time) {
   # We want vec(t(Y)) where Y = space %*% X %*% t(time) and X = sites × times.
   # Since matrix(v, n_times, n_sites) is already t(X), and
@@ -36,6 +38,7 @@ kron_mv <- function(v, space, time) {
 #' @param N Total length of the full vector.
 #'
 #' @return A numeric vector of length `N` with `x_obs` scattered at `obs_idx`.
+#' @keywords internal
 fill_vector <- function(x_obs, obs_idx, N){
   v <- numeric(N)
   v[obs_idx] <- x_obs
@@ -48,11 +51,11 @@ fill_vector <- function(x_obs, obs_idx, N){
 #' plus a per-observation noise (nugget), all without building any big matrices.
 #'
 #' Technically: for \eqn{K = \mathrm{space}\,\otimes\,\mathrm{time}}, returns
-#' \deqn{S\,K\,S^{\mathsf T}\,v \;+\; \operatorname{diag}(\sigma^2)\,v,}
+#' \deqn{S\,K\,S^{\top}\,v \;+\; \nu\,v,}
 #' i.e., the observed block of the GP plus a diagonal nugget. Implemented
 #' matrix-free as \code{kron_mv(with_nas(v, obs_idx, N), space_mat, time_mat)[obs_idx] + noise_var * v},
-#' where \eqn{S^{\mathsf T}} “scatters’’ into the full vector and \eqn{\sigma^2}
-#' denotes the per-observation noise.
+#' where \eqn{S^{\top}} "scatters" into the full vector and \eqn{\nu}
+#' denotes the per-observation noise (scalar or per-observation vector).
 #'
 #' @param v Numeric vector of length \eqn{m} (observed entries).
 #' @param obs_idx Integer indices of observed entries in the full vector.
@@ -62,6 +65,7 @@ fill_vector <- function(x_obs, obs_idx, N){
 #' @param noise_var Scalar or length-\eqn{m} numeric nugget on the observed scale.
 #'
 #' @return A numeric vector of length \eqn{m}, equal to \eqn{(S K S^\top + D)v}.
+#' @keywords internal
 Amv <- function(v, obs_idx, N, space_mat, time_mat, noise_var) {
   #browser()
   kron_mv(fill_vector(v, obs_idx, N), space_mat, time_mat)[obs_idx] + noise_var * v
@@ -70,10 +74,10 @@ Amv <- function(v, obs_idx, N, space_mat, time_mat, noise_var) {
 #' Conjugate Gradient (CG) solver for the observed system
 #'
 #' In plain terms: solves the big linear system that gives the GP weights using
-#' only matrix–vector products—no huge matrices, no explicit inverse.
+#' only matrix-vector products -- no huge matrices, no explicit inverse.
 #'
 #' Technically: solves \eqn{(S K S^\top + \mathrm{diag}(\text{noise}))\,x = b}
-#' by plain CG, using `Amv` for matrix–vector products. Stops when the relative
+#' by plain CG, using `Amv` for matrix-vector products. Stops when the relative
 #' residual falls below `tol` or after `maxit` iterations (issues a warning on
 #' `maxit`).
 #'
@@ -93,6 +97,7 @@ Amv <- function(v, obs_idx, N, space_mat, time_mat, noise_var) {
 #' @param maxit Maximum number of iterations (default `10000`).
 #'
 #' @return Numeric solution vector `x` of length \eqn{m}.
+#' @keywords internal
 cg <- function(b, obs_idx, N, space_mat, time_mat, noise_var, tol = 1e-8, maxit = 10000) {
   b_norm  <- sqrt(sum(b * b))
   x <- numeric(length(b))

--- a/R/curve_progress.R
+++ b/R/curve_progress.R
@@ -13,7 +13,7 @@
 #
 # Internal helper (not exported); used by gp_predict() for the
 # posterior-draw loop. Requires a UTF-8 terminal with ANSI truecolor
-# (any modern terminal, or the RStudio terminal pane).
+# (any modern terminal, or the RStudio/Positron console).
 #
 # Usage:
 #   pb <- make_curve_bar(total = 100)

--- a/R/data.R
+++ b/R/data.R
@@ -5,11 +5,12 @@
 #'
 #' @param data A data frame containing site identifiers, time `t`,
 #'   counts `n`, and coordinates `lat` and `lon`.
-#' @param ... Columns identifying sites passed to [dplyr::group_by()]
-#'   (unquoted).
+#' @param ... Bare (unquoted) column names that jointly identify a site,
+#'   e.g. `region, facility_name`.
 #'
 #' @return A data frame with missing site-time combinations filled in and
 #'   `n` set to `NA`.
+#' @keywords internal
 data_complete <- function(data, ...){
   site_names <- rlang::ensyms(...)
 
@@ -41,12 +42,13 @@ data_complete <- function(data, ...){
 #'
 #' @param data A data frame containing site identifiers, time `t`,
 #'   counts `n`, and coordinates `lat` and `lon`.
-#' @param ... Columns identifying sites passed to [dplyr::group_by()]
-#'   (unquoted).
+#' @param ... Bare (unquoted) column names that jointly identify a site,
+#'   e.g. `region, facility_name`.
 #' @param drop_zero Logical; also drop sites whose observed counts sum to zero
 #'   (default `FALSE`).
 #'
 #' @return A data frame with problem sites removed.
+#' @keywords internal
 data_missing <- function(data, ..., drop_zero = FALSE){
   site_names <- rlang::enquos(...)
 
@@ -112,10 +114,11 @@ data_missing <- function(data, ..., drop_zero = FALSE){
 #' Arranges data by site and time and creates a factor `id` per site.
 #'
 #' @param data A data frame containing site identifiers and time `t`.
-#' @param ... Columns identifying sites passed to [dplyr::group_by()]
-#'   (unquoted).
+#' @param ... Bare (unquoted) column names that jointly identify a site,
+#'   e.g. `region, facility_name`.
 #'
 #' @return A data frame ordered by site and time with an `id` column.
+#' @keywords internal
 data_order_index <- function(data, ...){
   site_names <- rlang::enquos(...)
 
@@ -145,8 +148,8 @@ data_order_index <- function(data, ...){
 #'
 #' @param data A data frame containing site identifiers, time `t`,
 #'   counts `n`, and coordinates `lat` and `lon`.
-#' @param ... Columns identifying sites passed to [dplyr::group_by()]
-#'   (unquoted).
+#' @param ... Bare (unquoted) column names that jointly identify a site,
+#'   e.g. `data_process(raw, region, facility_name)`.
 #' @param drop_zero Logical; passed to [data_missing()] -- also drop sites whose
 #'   observed counts sum to zero (default `FALSE`).
 #'
@@ -161,7 +164,7 @@ data_order_index <- function(data, ...){
 #' @export
 data_process <- function(data, ..., drop_zero = FALSE){
   if(!all(c("t", "n", "lat", "lon") %in% colnames(data))){
-    stop("Input data must include the following columns: t, n, lat and lon"
+    stop("Input data must include the following columns: t, n, lat, and lon"
     )
   }
 

--- a/R/hyperparameters.R
+++ b/R/hyperparameters.R
@@ -2,9 +2,9 @@
 # Quick, exact kernel-hyperparameter estimation.
 #
 # Goal: a fast, deterministic estimate of the separable-GP kernel
-# hyperparameters that is more defensible than the cross-validated /
-# working-Gaussian approach in fit_hyperparameters.R, but does NOT require an
-# MCMC or the matrix-free CG sampler. Some pragmatic approximation is fine.
+# hyperparameters that is more defensible than a cross-validated /
+# working-Gaussian approach, but does NOT require an MCMC or the matrix-free
+# CG sampler. Some pragmatic approximation is fine.
 #
 # Idea: form a cheap *plug-in* latent field g directly from the counts
 # (per-site-centred log1p(y), see build_plugin_field), then fit the GP by
@@ -38,10 +38,10 @@
 
 #' Default priors for the kernel hyperparameters
 #'
-#' Weakly-informative log-normal priors (i.e. Normal priors on the log scale) on
+#' Weakly informative log-normal priors (i.e. Normal priors on the log scale) on
 #' `length_scale`, `periodic_scale`, `long_term_scale` and the noise-to-signal
 #' ratio `nugget_ratio`. They act as mild regularisation on an otherwise
-#' maximum-likelihood fit, keeping weakly-identified parameters (notably
+#' maximum-likelihood fit, keeping weakly identified parameters (notably
 #' `long_term_scale`) away from the boundary.
 #'
 #' @return A named list of `list(meanlog, sdlog)` priors.
@@ -79,8 +79,9 @@ eig_sym <- function(K, floor = 1e-12) {
 #'
 #' Forms a cheap estimate of the latent log-intensity field as the per-site
 #' centred (and optionally scaled) `log1p` of the observed counts. Missing cells
-#' are mean-imputed (0 after centring) and therefore contribute nothing to the
-#' marginal likelihood.
+#' are filled with the per-site mean (zero after centring) -- a neutral fill
+#' that carries no signal of its own. See `refine = TRUE` in
+#' [infer_kernel_params()] for a correlation-aware fill.
 #'
 #' Per-site centring removes the site intercept `mu_s`; per-site scaling
 #' homogenises per-site variances so a single global `sigma^2` and the
@@ -129,7 +130,14 @@ build_plugin_field <- function(obs_data, n, nt, value = "y_obs", standardise = T
 #' global variance `sigma^2` is profiled out (concentrated log-likelihood) and
 #' the profiled value is attached as `attr(., "sigma2")`.
 #'
-#' @param g Plug-in field, length `n * nt`, ordered sites x times (time fastest).
+#' [infer_kernel_params()] maximises this quantity for you; call it directly
+#' when you want to score a candidate set of hyperparameters yourself (e.g.
+#' profiling a likelihood surface). The kernels should be correlation matrices
+#' (unit diagonal) as built by [space_kernel()] / [time_kernel()], decomposed
+#' with `eigen(., symmetric = TRUE)`.
+#'
+#' @param g Plug-in field, length `n * nt`, ordered sites x times (time
+#'   fastest), as returned by [build_plugin_field()].
 #' @param n Number of sites.
 #' @param nt Number of time points.
 #' @param eig_s Eigendecomposition (`eigen` object) of the spatial correlation
@@ -140,6 +148,17 @@ build_plugin_field <- function(obs_data, n, nt, value = "y_obs", standardise = T
 #'
 #' @return The concentrated log-likelihood (numeric scalar), with the profiled
 #'   `sigma2` attached as an attribute.
+#'
+#' @examples
+#' n <- 5; nt <- 20
+#' coords <- data.frame(id = 1:n, lon = runif(n), lat = runif(n))
+#' g <- stats::rnorm(n * nt)
+#' eig_s <- eigen(space_kernel(coords, length_scale = 1), symmetric = TRUE)
+#' eig_t <- eigen(time_kernel(1:nt, periodic_scale = 1, long_term_scale = 50,
+#'                            period = 52), symmetric = TRUE)
+#' ll <- gp_marginal_loglik(g, n, nt, eig_s, eig_t, eta = 0.1)
+#' ll
+#' attr(ll, "sigma2")  # the profiled global variance
 #' @export
 gp_marginal_loglik <- function(g, n, nt, eig_s, eig_t, eta) {
   F_mat <- t(matrix(g, nrow = nt, ncol = n))               # n x nt, time fastest
@@ -255,6 +274,12 @@ complete_field_cond_mean <- function(obs_data, coordinates, n, nt, period,
 #' wanted (e.g. as a starting point for a downstream sampler, or as a standalone
 #' summary).
 #'
+#' Strictly, the score maximised is the marginal likelihood *plus* weakly
+#' informative log-normal priors on the four parameters (a MAP estimate; see
+#' [default_kernel_priors()]). The priors act as mild regularisation that
+#' keeps weakly identified parameters -- notably `long_term_scale` -- away
+#' from the boundary; pass `priors` to change them.
+#'
 #' Set `refine` to enable an EM-style refinement that removes the bias missing
 #' cells introduce. Each pass refits after replacing the gaps with the GP
 #' posterior (conditional) mean under the current estimate -- a correlation-aware
@@ -270,8 +295,9 @@ complete_field_cond_mean <- function(obs_data, coordinates, n, nt, period,
 #'   real elapsed time, so gaps and uneven spacing between time points are
 #'   modelled as genuine time distances (use e.g. weeks or days since a
 #'   reference). [gp_predict()] must be given the same `t` encoding.
-#' @param coordinates Site coordinates (data frame with `lon`, `lat`), ordered
-#'   to match `sort(unique(obs_data$id))`.
+#' @param coordinates Site coordinates: a data frame with `id`, `lon`, `lat`,
+#'   one row per site in `obs_data` (rows are matched by `id`, so order does
+#'   not matter).
 #' @param nt Number of time points.
 #' @param period Period of the seasonal cycle, in the same units as `t`.
 #' @param value Name of the count column (default `"y_obs"`).
@@ -283,8 +309,8 @@ complete_field_cond_mean <- function(obs_data, coordinates, n, nt, period,
 #' @param n_sites Optional integer. If supplied and smaller than the number of
 #'   sites, the hyperparameters are estimated from a random subsample of this
 #'   many sites. The kernel hyperparameters are shared, population-level
-#'   quantities, so a representative site subsample estimates the same length
-#'   scales at a fraction of the \eqn{O(n^3)} cost -- useful for very large site
+#'   quantities, so a representative site subsample estimates the same
+#'   length-scales at a fraction of the \eqn{O(n^3)} cost -- useful for very large site
 #'   counts. Default `NULL` uses all sites. The subsample is drawn from the
 #'   current RNG state, so set a seed beforehand (e.g. [set.seed()]) for a
 #'   reproducible estimate. Note: this subsamples *sites* only, not time points
@@ -325,7 +351,7 @@ infer_kernel_params <- function(obs_data, coordinates, nt, period,
   coord_idx <- match(sort(unique(obs_data$id)), coordinates$id)
   if (anyNA(coord_idx)) {
     stop(
-      "`coordinates` has no row for every site `id` in `obs_data`.",
+      "`coordinates` is missing a row for one or more site `id`s in `obs_data`.",
       call. = FALSE
     )
   }

--- a/R/kernel.R
+++ b/R/kernel.R
@@ -1,10 +1,15 @@
 #' Radial basis function kernel
 #'
 #' Computes the radial basis function (RBF) kernel for a distance vector
-#' or matrix.
+#' or matrix:
+#' \deqn{k(d) = \exp\left(-\frac{d^2}{2\theta^2}\right).}
+#' This is the correlation form of the kernel (\eqn{k(0) = 1}); any global
+#' variance is applied separately.
 #'
 #' @param x A numeric vector or matrix of distances.
-#' @param theta A positive numeric scalar giving the length-scale parameter.
+#' @param theta A positive numeric scalar giving the length-scale parameter
+#'   (the \eqn{\ell} of textbook presentations): correlation decays with
+#'   distance over this scale, so larger values give smoother functions.
 #'
 #' @return A numeric vector or matrix with RBF kernel values.
 #' @export
@@ -14,11 +19,14 @@ rbf_kernel <- function(x, theta) {
 
 #' Periodic kernel
 #'
-#' Computes a periodic kernel for a distance vector or matrix.
+#' Computes a periodic kernel for a distance vector or matrix:
+#' \deqn{k(d) = \exp\left(-\frac{2\sin^2(\pi d / p)}{\alpha^2}\right).}
 #'
 #' @param x A numeric vector or matrix of distances.
-#' @param alpha A positive numeric scalar controlling the amplitude.
-#' @param period A positive numeric scalar giving the period.
+#' @param alpha A positive numeric scalar controlling how sharply correlation
+#'   falls within each cycle: smaller values allow sharp seasonal peaks;
+#'   larger values give a gentler, smoother cycle.
+#' @param period A positive numeric scalar giving the period \eqn{p}.
 #'
 #' @return A numeric vector or matrix of periodic kernel values.
 #' @export
@@ -28,9 +36,13 @@ periodic_kernel <- function(x, alpha, period) {
 
 #' Pairwise spatial distances
 #'
-#' Computes pairwise Euclidean distances between locations.
+#' Computes pairwise Euclidean distances between locations, in the units of
+#' the coordinates. No great-circle correction is applied: with raw
+#' longitude/latitude degrees, one degree of longitude shrinks with latitude,
+#' so for large or high-latitude extents project the coordinates first (e.g.
+#' to km) and interpret `length_scale` in those units.
 #'
-#' @param coordinates A data frame with columns `lon` and `lat` in degrees.
+#' @param coordinates A data frame with columns `lon` and `lat`.
 #'
 #' @return A symmetric matrix of pairwise spatial distances.
 #' @export
@@ -52,17 +64,19 @@ get_temporal_distance <- function(times) {
     as.matrix()
 }
 
-#' Estimate the spatial kernel
+#' Build the spatial correlation matrix
 #'
-#' Builds a spatial covariance matrix using an RBF kernel with a nugget
-#' term for numerical stability.
+#' Builds a spatial correlation matrix using an RBF kernel with a nugget
+#' term for numerical stability. Distances are Euclidean in the coordinate
+#' units (see [get_spatial_distance()]), so `length_scale` is in those same
+#' units.
 #'
-#' @param coordinates A data frame with columns `lon` and `lat` in degrees.
-#' @param length_scale A positive numeric scalar for the spatial length scale.
+#' @param coordinates A data frame with columns `lon` and `lat`.
+#' @param length_scale A positive numeric scalar for the spatial length-scale.
 #' @param nugget A non-negative numeric scalar added to the diagonal for
 #'   numerical stability.
 #'
-#' @return A positive-definite matrix representing spatial covariance.
+#' @return A positive-definite matrix representing spatial correlation.
 #' @export
 space_kernel <- function(coordinates, length_scale, nugget = 1e-9) {
   space_matrix <- get_spatial_distance(coordinates)
@@ -70,22 +84,23 @@ space_kernel <- function(coordinates, length_scale, nugget = 1e-9) {
     diag(x = nugget, nrow = nrow(space_matrix))
 }
 
-#' Estimate the temporal kernel
+#' Build the temporal correlation matrix
 #'
-#' Builds a temporal covariance matrix by combining periodic and
+#' Builds a temporal correlation matrix by combining periodic and
 #' long-term RBF components with a nugget term for numerical stability.
 #'
 #' @param times A numeric vector of time indices.
-#' @param periodic_scale A positive numeric scalar controlling the periodic
-#'   variation.
-#' @param long_term_scale A positive numeric scalar for the long-term length
-#'   scale.
+#' @param periodic_scale A positive numeric scalar controlling how sharply
+#'   correlation falls within each seasonal cycle: smaller values allow sharp
+#'   seasonal peaks; larger values give a gentler, smoother cycle.
+#' @param long_term_scale A positive numeric scalar for the long-term
+#'   length-scale.
 #' @param nugget A non-negative numeric scalar added to the diagonal for
 #'   numerical stability.
 #' @param period A positive numeric scalar giving the period of the seasonal
-#'   component.
+#'   component, in the same units as `times`.
 #'
-#' @return A positive-definite matrix representing temporal covariance.
+#' @return A positive-definite matrix representing temporal correlation.
 #' @export
 time_kernel <- function(times, periodic_scale, long_term_scale,
                         nugget = 1e-9, period = 52) {

--- a/R/predict.R
+++ b/R/predict.R
@@ -55,11 +55,12 @@
 #' @param Rs_chol,Rt_chol Upper Cholesky factors of `space_mat` / `time_mat`.
 #' @param n_draws Number of paired draws for the missing-data correction.
 #' @param tol CG tolerance for the draw solves.
-#' @param progress_bar Optional progress bar (from [make_curve_bar()]); ticked
+#' @param progress_bar Optional progress bar (from `make_curve_bar()`); ticked
 #'   once per draw. Only effective under a single-worker plan (parallel
 #'   workers cannot tick a bar in the calling session).
 #'
 #' @return Numeric vector of length `N`: the posterior variance of the field.
+#' @keywords internal
 gp_posterior_var <- function(obs_idx, N, space_mat, time_mat, noise_var,
                              Rs_chol, Rt_chol, n_draws, tol = 1e-3,
                              progress_bar = NULL) {
@@ -127,6 +128,12 @@ gp_posterior_var <- function(obs_idx, N, space_mat, time_mat, noise_var,
 #' genuine GP interpolation and their prediction interval can widen over gaps --
 #' unlike a completed-grid smoother that mean-imputes the gaps.
 #'
+#' Predictions are made at every `(id, t)` cell present in `obs_data`. To
+#' predict at time points with no data anywhere (e.g. a future week), append
+#' rows with `NA` counts for those times (every site) and increase `nt`
+#' accordingly; the interval widens with distance from the data. Treat
+#' extrapolation beyond the observed range with the usual caution.
+#'
 #' @param obs_data Data frame with `id` (site), `t` (time) and a count column
 #'   named by `value` (`NA` where missing). `t` is a numeric time index whose
 #'   *differences* encode real elapsed time, so gaps and uneven spacing between
@@ -161,7 +168,7 @@ gp_posterior_var <- function(obs_idx, N, space_mat, time_mat, noise_var,
 #' @param progress Logical; show a progress bar over the posterior-draw loop
 #'   (the expensive part). Defaults to `TRUE`, but the bar is drawn only in an
 #'   interactive UTF-8 / truecolor terminal -- it stays silent in scripts,
-#'   knitr, logs and CI. Under a multi-worker [future::plan()] the bar is
+#'   knitr, logs, and CI. Under a multi-worker [future::plan()] the bar is
 #'   suppressed (workers cannot tick it). Set `FALSE` to disable it entirely.
 #'
 #' @section Parallel execution:
@@ -188,7 +195,8 @@ gp_posterior_var <- function(obs_idx, N, space_mat, time_mat, noise_var,
 #' by default there is nothing to do. See
 #' `vignette("parallel", package = "weave")` for a walkthrough.
 #'
-#' @return A data frame with one row per cell and columns `id`, `t`, `rate`
+#' @return A data frame with one row per site-by-time cell (site-week) and
+#'   columns `id`, `t`, `rate`
 #'   (posterior point estimate of \eqn{\lambda}), and -- when `n_draws >= 1` --
 #'   `lower` and `upper` (the 95% count prediction interval). The dispersion `r`
 #'   used and `n_draws` are attached as attributes.
@@ -236,7 +244,7 @@ gp_predict <- function(
   coord_idx <- match(ids, coordinates$id)
   if (anyNA(coord_idx)) {
     stop(
-      "`coordinates` has no row for every site `id` in `obs_data`.",
+      "`coordinates` is missing a row for one or more site `id`s in `obs_data`.",
       call. = FALSE
     )
   }

--- a/R/predict.R
+++ b/R/predict.R
@@ -153,6 +153,11 @@ gp_posterior_var <- function(obs_idx, N, space_mat, time_mat, noise_var,
 #'   correction, modest values (25--100) already give tight intervals.
 #' @param r Negative-Binomial dispersion for the count interval. If `NULL`
 #'   (default) it is estimated by method of moments from the observed counts.
+#'   `Inf` is valid and means Poisson observation noise (no overdispersion);
+#'   the method-of-moments estimate returns `Inf` itself when the data show
+#'   no excess variance, so `attr(., "r")` on the result can be `Inf`. The
+#'   distribution affects only the interval width -- the `rate` column does
+#'   not depend on it.
 #' @param value Name of the count column (default `"y_obs"`).
 #' @param standardise Logical; standardise the plug-in field per site (default
 #'   `TRUE`), matching [infer_kernel_params()].

--- a/R/sample.R
+++ b/R/sample.R
@@ -1,12 +1,21 @@
-#' Quick multivariate normal samples over two dimensions
+#' Quick multivariate normal draw over two dimensions
 #'
-#' This is equivalent to estimating the full spatio-temporal covariance matrix
-#' and sampling from the multivariate normal distribution:
-#' full_k <- kronecker(dist_k, time_k)
-#' f  <- mvrnorm(1, rep(0, n * nt), full_k)
+#' Draws one sample from a zero-mean Gaussian with separable space-time
+#' covariance, without ever forming the full matrix. This is equivalent to
+#' forming the full spatio-temporal covariance and drawing from the
+#' multivariate normal distribution:
 #'
-#' @param space Space kernel matrix
-#' @param time  Time kernel matrix
+#' ```r
+#' full_k <- kronecker(space, time)
+#' f <- MASS::mvrnorm(1, rep(0, nrow(space) * nrow(time)), full_k)
+#' ```
+#'
+#' @param space Space kernel matrix.
+#' @param time Time kernel matrix.
+#'
+#' @return A numeric vector of length `nrow(space) * nrow(time)`, ordered
+#'   site by site with time varying fastest (matching
+#'   `kronecker(space, time)`).
 #' @export
 quick_mvnorm <- function(space, time) {
   n_sites <- nrow(space)
@@ -29,15 +38,21 @@ quick_mvnorm <- function(space, time) {
 }
 
 
-#' Quick multivariate normal samples over two dimensions (cholesky precomputed)
+#' Quick multivariate normal draw over two dimensions (Cholesky precomputed)
 #'
-#' This is equivalent to estimating the full spatio-temporal covariance matrix
-#' and sampling from the multivariate normal distribution:
-#' full_k <- kronecker(dist_k, time_k)
-#' f  <- mvrnorm(1, rep(0, n * nt), full_k)
+#' As [quick_mvnorm()], but taking precomputed Cholesky factors so repeated
+#' draws (e.g. the perturbation draws in [gp_predict()]) skip the
+#' factorisation cost.
 #'
-#' @param space_chol Cholesky decomposition of sapace kernel matrix
-#' @param time_chol  Cholesky decomposition of time kernel matrix
+#' @param space_chol Upper-triangular Cholesky factor of the space kernel
+#'   matrix, as returned by [chol()]. Passing the lower-triangular factor
+#'   gives silently wrong draws.
+#' @param time_chol Upper-triangular Cholesky factor of the time kernel
+#'   matrix, as returned by [chol()].
+#'
+#' @return A numeric vector of length `nrow(space_chol) * nrow(time_chol)`,
+#'   ordered site by site with time varying fastest (matching
+#'   `kronecker(space, time)`).
 #' @export
 quick_mvnorm_chol <- function(space_chol, time_chol) {
   n_sites <- nrow(space_chol)

--- a/README.Rmd
+++ b/README.Rmd
@@ -32,8 +32,8 @@ across space and time, modelled as a separable Gaussian process — a spatial
 kernel combined with a temporal kernel (periodic season × long-term drift). In
 three steps it:
 
-1. **builds a quick plug-in field** from the counts (per-site standardised
-   `log(1 + y)`);
+1. **builds a quick rough estimate of the smooth signal** behind the counts
+   (per-site standardised `log(1 + y)` — the "plug-in field");
 2. **estimates the kernel hyperparameters** — how fast counts decorrelate
    across space, within the season, and over the long term — by maximising the
    Gaussian-process marginal likelihood, kept fast by the kernel's Kronecker
@@ -45,7 +45,7 @@ three steps it:
 
 ## Installation
 
-You can install the development version of weave from [GitHub](https://github.com/) with:
+You can install the development version of `weave` from [GitHub](https://github.com/) with:
 
 ``` r
 # install.packages("pak")
@@ -55,15 +55,25 @@ pak::pak("mrc-ide/weave")
 ## Getting started
 
 `weave` needs two inputs: `obs_data`, a data frame with columns `id` (site),
-`t` (week) and `y_obs` (the count, `NA` where missing); and `coordinates`,
-giving each site's `lon`/`lat`. The workflow is two calls — estimate the
+`t` (a numeric time index whose differences encode real elapsed time, e.g.
+weeks since a reference) and `y_obs` (the count, `NA` where missing); and
+`coordinates`, giving each site's `id` and `lon`/`lat`. If you are starting
+from one raw data frame, `data_process()` returns `obs_data`, `coordinates`
+and `nt` in exactly this shape. The workflow is then two calls — estimate the
 kernels, then predict:
 
 ``` r
 library(weave)
 
+prepared <- data_process(raw_data, facility_name)   # raw -> model-ready
+obs_data    <- prepared$obs_data
+coordinates <- prepared$coordinates
+nt          <- prepared$nt
+
 # 1. estimate the spatial + temporal kernel length-scales
-est <- infer_kernel_params(obs_data, coordinates, nt = nt, period = 52)
+#    (with missing weeks, refine = TRUE removes the gap-induced bias)
+est <- infer_kernel_params(obs_data, coordinates, nt = nt, period = 52,
+                           refine = TRUE)
 
 # 2. predict the rate, fill the gaps, and attach a 95% prediction interval
 pred <- gp_predict(obs_data, coordinates, hyperparameters = est,
@@ -80,4 +90,10 @@ prediction interval.
 - [The weave walkthrough](https://mrc-ide.github.io/weave/articles/walkthrough.html)
   — the full method worked end to end, from estimating the kernels to predicting
   rates with honest uncertainty.
+- [Using weave with your own data](https://mrc-ide.github.io/weave/articles/data-preparation.html)
+  — preparing raw data with `data_process()`, encoding time correctly, and
+  predicting beyond the observed weeks.
+- [Running predictions in parallel](https://mrc-ide.github.io/weave/articles/parallel.html)
+  — one line of setup to spread the prediction draws across CPU cores;
+  identical results.
 

--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ varies across space and time, modelled as a separable Gaussian process —
 a spatial kernel combined with a temporal kernel (periodic season ×
 long-term drift). In three steps it:
 
-1.  **builds a quick plug-in field** from the counts (per-site
-    standardised `log(1 + y)`);
+1.  **builds a quick rough estimate of the smooth signal** behind the
+    counts (per-site standardised `log(1 + y)` — the “plug-in field”);
 2.  **estimates the kernel hyperparameters** — how fast counts
     decorrelate across space, within the season, and over the long term
     — by maximising the Gaussian-process marginal likelihood, kept fast
@@ -35,7 +35,7 @@ long-term drift). In three steps it:
 
 ## Installation
 
-You can install the development version of weave from
+You can install the development version of `weave` from
 [GitHub](https://github.com/) with:
 
 ``` r
@@ -46,15 +46,25 @@ pak::pak("mrc-ide/weave")
 ## Getting started
 
 `weave` needs two inputs: `obs_data`, a data frame with columns `id`
-(site), `t` (week) and `y_obs` (the count, `NA` where missing); and
-`coordinates`, giving each site’s `lon`/`lat`. The workflow is two calls
-— estimate the kernels, then predict:
+(site), `t` (a numeric time index whose differences encode real elapsed
+time, e.g. weeks since a reference) and `y_obs` (the count, `NA` where
+missing); and `coordinates`, giving each site’s `id` and `lon`/`lat`. If
+you are starting from one raw data frame, `data_process()` returns
+`obs_data`, `coordinates` and `nt` in exactly this shape. The workflow
+is then two calls — estimate the kernels, then predict:
 
 ``` r
 library(weave)
 
+prepared <- data_process(raw_data, facility_name)   # raw -> model-ready
+obs_data    <- prepared$obs_data
+coordinates <- prepared$coordinates
+nt          <- prepared$nt
+
 # 1. estimate the spatial + temporal kernel length-scales
-est <- infer_kernel_params(obs_data, coordinates, nt = nt, period = 52)
+#    (with missing weeks, refine = TRUE removes the gap-induced bias)
+est <- infer_kernel_params(obs_data, coordinates, nt = nt, period = 52,
+                           refine = TRUE)
 
 # 2. predict the rate, fill the gaps, and attach a 95% prediction interval
 pred <- gp_predict(obs_data, coordinates, hyperparameters = est,
@@ -74,3 +84,11 @@ pred <- gp_predict(obs_data, coordinates, hyperparameters = est,
   walkthrough](https://mrc-ide.github.io/weave/articles/walkthrough.html)
   — the full method worked end to end, from estimating the kernels to
   predicting rates with honest uncertainty.
+- [Using weave with your own
+  data](https://mrc-ide.github.io/weave/articles/data-preparation.html)
+  — preparing raw data with `data_process()`, encoding time correctly,
+  and predicting beyond the observed weeks.
+- [Running predictions in
+  parallel](https://mrc-ide.github.io/weave/articles/parallel.html) —
+  one line of setup to spread the prediction draws across CPU cores;
+  identical results.

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -18,4 +18,29 @@ articles:
   contents:
   - gaussian-processes
   - walkthrough
+  - data-preparation
   - parallel
+
+reference:
+- title: Core workflow
+  desc: Prepare the data, estimate the kernel hyperparameters, predict.
+  contents:
+  - data_process
+  - infer_kernel_params
+  - gp_predict
+- title: Kernels and distances
+  contents:
+  - space_kernel
+  - time_kernel
+  - rbf_kernel
+  - periodic_kernel
+  - get_spatial_distance
+  - get_temporal_distance
+- title: Building blocks
+  desc: The pieces the workflow is assembled from, exported for direct use.
+  contents:
+  - build_plugin_field
+  - gp_marginal_loglik
+  - default_kernel_priors
+  - quick_mvnorm
+  - quick_mvnorm_chol

--- a/implementation/walkthrough.R
+++ b/implementation/walkthrough.R
@@ -105,7 +105,7 @@ observed_data <- function(data, p_one, p_switch) {
 # 1. Controls
 # -----------------------------------------------------------------------------
 n <- 100 # number of sites (health facilities)
-nt <- 52 * 5 # number of time points (3 yrs weekly)
+nt <- 52 * 5 # number of time points (5 yrs weekly)
 period <- 52 # seasonal period (weeks/cycle)
 
 true_length_scale <- 0.5 # spatial smoothness (distance units)

--- a/man/Amv.Rd
+++ b/man/Amv.Rd
@@ -28,9 +28,10 @@ plus a per-observation noise (nugget), all without building any big matrices.
 }
 \details{
 Technically: for \eqn{K = \mathrm{space}\,\otimes\,\mathrm{time}}, returns
-\deqn{S\,K\,S^{\mathsf T}\,v \;+\; \operatorname{diag}(\sigma^2)\,v,}
+\deqn{S\,K\,S^{\top}\,v \;+\; \nu\,v,}
 i.e., the observed block of the GP plus a diagonal nugget. Implemented
 matrix-free as \code{kron_mv(with_nas(v, obs_idx, N), space_mat, time_mat)[obs_idx] + noise_var * v},
-where \eqn{S^{\mathsf T}} “scatters’’ into the full vector and \eqn{\sigma^2}
-denotes the per-observation noise.
+where \eqn{S^{\top}} "scatters" into the full vector and \eqn{\nu}
+denotes the per-observation noise (scalar or per-observation vector).
 }
+\keyword{internal}

--- a/man/build_plugin_field.Rd
+++ b/man/build_plugin_field.Rd
@@ -7,30 +7,31 @@
 build_plugin_field(obs_data, n, nt, value = "y_obs", standardise = TRUE)
 }
 \arguments{
-\item{obs_data}{Data frame with `id` (site), `t` (time) and the count column
-named by `value`.}
+\item{obs_data}{Data frame with \code{id} (site), \code{t} (time) and the count column
+named by \code{value}.}
 
 \item{n}{Number of sites.}
 
 \item{nt}{Number of time points.}
 
-\item{value}{Name of the count column (default `"y_obs"`).}
+\item{value}{Name of the count column (default \code{"y_obs"}).}
 
 \item{standardise}{Logical; scale each site to unit variance after centring
-(default `TRUE`).}
+(default \code{TRUE}).}
 }
 \value{
-A numeric vector of length `n * nt`, ordered sites x times (time
-  fastest).
+A numeric vector of length \code{n * nt}, ordered sites x times (time
+fastest).
 }
 \description{
 Forms a cheap estimate of the latent log-intensity field as the per-site
-centred (and optionally scaled) `log1p` of the observed counts. Missing cells
-are mean-imputed (0 after centring) and therefore contribute nothing to the
-marginal likelihood.
+centred (and optionally scaled) \code{log1p} of the observed counts. Missing cells
+are filled with the per-site mean (zero after centring) -- a neutral fill
+that carries no signal of its own. See \code{refine = TRUE} in
+\code{\link[=infer_kernel_params]{infer_kernel_params()}} for a correlation-aware fill.
 }
 \details{
-Per-site centring removes the site intercept `mu_s`; per-site scaling
-homogenises per-site variances so a single global `sigma^2` and the
-*correlation* kernels apply.
+Per-site centring removes the site intercept \code{mu_s}; per-site scaling
+homogenises per-site variances so a single global \code{sigma^2} and the
+\emph{correlation} kernels apply.
 }

--- a/man/cg.Rd
+++ b/man/cg.Rd
@@ -19,26 +19,27 @@ cg(b, obs_idx, N, space_mat, time_mat, noise_var, tol = 1e-08, maxit = 10000)
 
 \item{noise_var}{Scalar or length-\eqn{m} nugget on the observed scale.}
 
-\item{tol}{Relative residual tolerance for convergence (default `1e-8`).}
+\item{tol}{Relative residual tolerance for convergence (default \code{1e-8}).}
 
-\item{maxit}{Maximum number of iterations (default `10000`).}
+\item{maxit}{Maximum number of iterations (default \code{10000}).}
 }
 \value{
-Numeric solution vector `x` of length \eqn{m}.
+Numeric solution vector \code{x} of length \eqn{m}.
 }
 \description{
 In plain terms: solves the big linear system that gives the GP weights using
-only matrix–vector products—no huge matrices, no explicit inverse.
+only matrix-vector products -- no huge matrices, no explicit inverse.
 }
 \details{
 Technically: solves \eqn{(S K S^\top + \mathrm{diag}(\text{noise}))\,x = b}
-by plain CG, using `Amv` for matrix–vector products. Stops when the relative
-residual falls below `tol` or after `maxit` iterations (issues a warning on
-`maxit`).
+by plain CG, using \code{Amv} for matrix-vector products. Stops when the relative
+residual falls below \code{tol} or after \code{maxit} iterations (issues a warning on
+\code{maxit}).
 
 Deliberately unpreconditioned: the separable kernel is built from
-*correlation* matrices (unit diagonal plus a constant nugget) and the noise
+\emph{correlation} matrices (unit diagonal plus a constant nugget) and the noise
 is a scalar, so \eqn{\mathrm{diag}(A)} is exactly constant. A Jacobi
 (diagonal) preconditioner therefore only rescales the residual and leaves
 the CG iterates unchanged -- it is an exact no-op here, so don't add one.
 }
+\keyword{internal}

--- a/man/data_complete.Rd
+++ b/man/data_complete.Rd
@@ -7,16 +7,17 @@
 data_complete(data, ...)
 }
 \arguments{
-\item{data}{A data frame containing site identifiers, time `t`,
-counts `n`, and coordinates `lat` and `lon`.}
+\item{data}{A data frame containing site identifiers, time \code{t},
+counts \code{n}, and coordinates \code{lat} and \code{lon}.}
 
-\item{...}{Columns identifying sites passed to [dplyr::group_by()]
-(unquoted).}
+\item{...}{Bare (unquoted) column names that jointly identify a site,
+e.g. \verb{region, facility_name}.}
 }
 \value{
 A data frame with missing site-time combinations filled in and
-  `n` set to `NA`.
+\code{n} set to \code{NA}.
 }
 \description{
-Adds rows for all combinations of site identifiers and time `t`.
+Adds rows for all combinations of site identifiers and time \code{t}.
 }
+\keyword{internal}

--- a/man/data_missing.Rd
+++ b/man/data_missing.Rd
@@ -7,26 +7,27 @@
 data_missing(data, ..., drop_zero = FALSE)
 }
 \arguments{
-\item{data}{A data frame containing site identifiers, time `t`,
-counts `n`, and coordinates `lat` and `lon`.}
+\item{data}{A data frame containing site identifiers, time \code{t},
+counts \code{n}, and coordinates \code{lat} and \code{lon}.}
 
-\item{...}{Columns identifying sites passed to [dplyr::group_by()]
-(unquoted).}
+\item{...}{Bare (unquoted) column names that jointly identify a site,
+e.g. \verb{region, facility_name}.}
 
 \item{drop_zero}{Logical; also drop sites whose observed counts sum to zero
-(default `FALSE`).}
+(default \code{FALSE}).}
 }
 \value{
 A data frame with problem sites removed.
 }
 \description{
 Removes sites that cannot be modelled and reports them. Sites with no
-observed counts (all `n` missing) or without coordinates (all `lat`/`lon`
+observed counts (all \code{n} missing) or without coordinates (all \code{lat}/\code{lon}
 missing) are always dropped. Sites whose observed counts are all zero are
-dropped only when `drop_zero = TRUE`.
+dropped only when \code{drop_zero = TRUE}.
 
-Under the `log1p` per-site-centred rate model an all-zero site is valid
+Under the \code{log1p} per-site-centred rate model an all-zero site is valid
 low-rate data, not a defect, so it is retained by default; set
-`drop_zero = TRUE` if all-zero facilities should be treated as reporting
+\code{drop_zero = TRUE} if all-zero facilities should be treated as reporting
 artefacts and removed.
 }
+\keyword{internal}

--- a/man/data_order_index.Rd
+++ b/man/data_order_index.Rd
@@ -7,14 +7,15 @@
 data_order_index(data, ...)
 }
 \arguments{
-\item{data}{A data frame containing site identifiers and time `t`.}
+\item{data}{A data frame containing site identifiers and time \code{t}.}
 
-\item{...}{Columns identifying sites passed to [dplyr::group_by()]
-(unquoted).}
+\item{...}{Bare (unquoted) column names that jointly identify a site,
+e.g. \verb{region, facility_name}.}
 }
 \value{
-A data frame ordered by site and time with an `id` column.
+A data frame ordered by site and time with an \code{id} column.
 }
 \description{
-Arranges data by site and time and creates a factor `id` per site.
+Arranges data by site and time and creates a factor \code{id} per site.
 }
+\keyword{internal}

--- a/man/data_process.Rd
+++ b/man/data_process.Rd
@@ -7,28 +7,28 @@
 data_process(data, ..., drop_zero = FALSE)
 }
 \arguments{
-\item{data}{A data frame containing site identifiers, time `t`,
-counts `n`, and coordinates `lat` and `lon`.}
+\item{data}{A data frame containing site identifiers, time \code{t},
+counts \code{n}, and coordinates \code{lat} and \code{lon}.}
 
-\item{...}{Columns identifying sites passed to [dplyr::group_by()]
-(unquoted).}
+\item{...}{Bare (unquoted) column names that jointly identify a site,
+e.g. \code{data_process(raw, region, facility_name)}.}
 
-\item{drop_zero}{Logical; passed to [data_missing()] -- also drop sites whose
-observed counts sum to zero (default `FALSE`).}
+\item{drop_zero}{Logical; passed to \code{\link[=data_missing]{data_missing()}} -- also drop sites whose
+observed counts sum to zero (default \code{FALSE}).}
 }
 \value{
 A list with three elements ready to pass to the model functions:
-  \describe{
-    \item{`obs_data`}{Observations with the site-identifier columns, the
-      factor `id`, time `t`, and the count column `y_obs` (`NA` where
-      missing).}
-    \item{`coordinates`}{One row per site with `id`, `lon` and `lat`.}
-    \item{`nt`}{The number of time points.}
-  }
+\describe{
+\item{\code{obs_data}}{Observations with the site-identifier columns, the
+factor \code{id}, time \code{t}, and the count column \code{y_obs} (\code{NA} where
+missing).}
+\item{\code{coordinates}}{One row per site with \code{id}, \code{lon} and \code{lat}.}
+\item{\code{nt}}{The number of time points.}
+}
 }
 \description{
 Validates and prepares input data into the shape consumed by
-[infer_kernel_params()] and [gp_predict()]: it completes the site-by-time
-grid, drops sites that cannot be modelled, assigns a factor site `id`, and
+\code{\link[=infer_kernel_params]{infer_kernel_params()}} and \code{\link[=gp_predict]{gp_predict()}}: it completes the site-by-time
+grid, drops sites that cannot be modelled, assigns a factor site \code{id}, and
 returns the observations and coordinates as separate, ready-to-use frames.
 }

--- a/man/default_kernel_priors.Rd
+++ b/man/default_kernel_priors.Rd
@@ -7,12 +7,12 @@
 default_kernel_priors()
 }
 \value{
-A named list of `list(meanlog, sdlog)` priors.
+A named list of \code{list(meanlog, sdlog)} priors.
 }
 \description{
-Weakly-informative log-normal priors (i.e. Normal priors on the log scale) on
-`length_scale`, `periodic_scale`, `long_term_scale` and the noise-to-signal
-ratio `nugget_ratio`. They act as mild regularisation on an otherwise
-maximum-likelihood fit, keeping weakly-identified parameters (notably
-`long_term_scale`) away from the boundary.
+Weakly informative log-normal priors (i.e. Normal priors on the log scale) on
+\code{length_scale}, \code{periodic_scale}, \code{long_term_scale} and the noise-to-signal
+ratio \code{nugget_ratio}. They act as mild regularisation on an otherwise
+maximum-likelihood fit, keeping weakly identified parameters (notably
+\code{long_term_scale}) away from the boundary.
 }

--- a/man/fill_vector.Rd
+++ b/man/fill_vector.Rd
@@ -15,9 +15,10 @@ full vector.}
 \item{N}{Total length of the full vector.}
 }
 \value{
-A numeric vector of length `N` with `x_obs` scattered at `obs_idx`.
+A numeric vector of length \code{N} with \code{x_obs} scattered at \code{obs_idx}.
 }
 \description{
 Put the observed entries back into their full-length vector,
 filling missing positions with zeros.
 }
+\keyword{internal}

--- a/man/get_spatial_distance.Rd
+++ b/man/get_spatial_distance.Rd
@@ -7,11 +7,15 @@
 get_spatial_distance(coordinates)
 }
 \arguments{
-\item{coordinates}{A data frame with columns `lon` and `lat` in degrees.}
+\item{coordinates}{A data frame with columns \code{lon} and \code{lat}.}
 }
 \value{
 A symmetric matrix of pairwise spatial distances.
 }
 \description{
-Computes pairwise Euclidean distances between locations.
+Computes pairwise Euclidean distances between locations, in the units of
+the coordinates. No great-circle correction is applied: with raw
+longitude/latitude degrees, one degree of longitude shrinks with latitude,
+so for large or high-latitude extents project the coordinates first (e.g.
+to km) and interpret \code{length_scale} in those units.
 }

--- a/man/gp_marginal_loglik.Rd
+++ b/man/gp_marginal_loglik.Rd
@@ -7,28 +7,47 @@
 gp_marginal_loglik(g, n, nt, eig_s, eig_t, eta)
 }
 \arguments{
-\item{g}{Plug-in field, length `n * nt`, ordered sites x times (time fastest).}
+\item{g}{Plug-in field, length \code{n * nt}, ordered sites x times (time
+fastest), as returned by \code{\link[=build_plugin_field]{build_plugin_field()}}.}
 
 \item{n}{Number of sites.}
 
 \item{nt}{Number of time points.}
 
-\item{eig_s}{Eigendecomposition (`eigen` object) of the spatial correlation
+\item{eig_s}{Eigendecomposition (\code{eigen} object) of the spatial correlation
 kernel.}
 
-\item{eig_t}{Eigendecomposition (`eigen` object) of the temporal correlation
+\item{eig_t}{Eigendecomposition (\code{eigen} object) of the temporal correlation
 kernel.}
 
 \item{eta}{Noise-to-signal ratio (nugget), a non-negative scalar.}
 }
 \value{
 The concentrated log-likelihood (numeric scalar), with the profiled
-  `sigma2` attached as an attribute.
+\code{sigma2} attached as an attribute.
 }
 \description{
-Evaluates the exact log-density of `g ~ N(0, sigma^2 ((R_s (x) R_t) + eta I))`
+Evaluates the exact log-density of \verb{g ~ N(0, sigma^2 ((R_s (x) R_t) + eta I))}
 given the eigendecompositions of the spatial and temporal correlation
 kernels, via the Kronecker log-determinant and quadratic-form identities. The
-global variance `sigma^2` is profiled out (concentrated log-likelihood) and
-the profiled value is attached as `attr(., "sigma2")`.
+global variance \code{sigma^2} is profiled out (concentrated log-likelihood) and
+the profiled value is attached as \code{attr(., "sigma2")}.
+}
+\details{
+\code{\link[=infer_kernel_params]{infer_kernel_params()}} maximises this quantity for you; call it directly
+when you want to score a candidate set of hyperparameters yourself (e.g.
+profiling a likelihood surface). The kernels should be correlation matrices
+(unit diagonal) as built by \code{\link[=space_kernel]{space_kernel()}} / \code{\link[=time_kernel]{time_kernel()}}, decomposed
+with \code{eigen(., symmetric = TRUE)}.
+}
+\examples{
+n <- 5; nt <- 20
+coords <- data.frame(id = 1:n, lon = runif(n), lat = runif(n))
+g <- stats::rnorm(n * nt)
+eig_s <- eigen(space_kernel(coords, length_scale = 1), symmetric = TRUE)
+eig_t <- eigen(time_kernel(1:nt, periodic_scale = 1, long_term_scale = 50,
+                           period = 52), symmetric = TRUE)
+ll <- gp_marginal_loglik(g, n, nt, eig_s, eig_t, eta = 0.1)
+ll
+attr(ll, "sigma2")  # the profiled global variance
 }

--- a/man/gp_posterior_var.Rd
+++ b/man/gp_posterior_var.Rd
@@ -20,7 +20,7 @@ gp_posterior_var(
 \arguments{
 \item{obs_idx}{Integer indices of observed cells in the full vector.}
 
-\item{N}{Total number of cells (`n * nt`).}
+\item{N}{Total number of cells (\code{n * nt}).}
 
 \item{space_mat}{Spatial kernel matrix (variance-scaled).}
 
@@ -28,18 +28,18 @@ gp_posterior_var(
 
 \item{noise_var}{Scalar observation-noise variance \eqn{\nu}.}
 
-\item{Rs_chol, Rt_chol}{Upper Cholesky factors of `space_mat` / `time_mat`.}
+\item{Rs_chol, Rt_chol}{Upper Cholesky factors of \code{space_mat} / \code{time_mat}.}
 
 \item{n_draws}{Number of paired draws for the missing-data correction.}
 
 \item{tol}{CG tolerance for the draw solves.}
 
-\item{progress_bar}{Optional progress bar (from [make_curve_bar()]); ticked
+\item{progress_bar}{Optional progress bar (from \code{make_curve_bar()}); ticked
 once per draw. Only effective under a single-worker plan (parallel
 workers cannot tick a bar in the calling session).}
 }
 \value{
-Numeric vector of length `N`: the posterior variance of the field.
+Numeric vector of length \code{N}: the posterior variance of the field.
 }
 \description{
 Estimates the per-cell posterior variance of the GP field conditioned on the
@@ -50,21 +50,22 @@ correction:
 }
 \details{
 \eqn{V_{\mathrm{complete}} = \operatorname{diag}(K - K(K+\nu I)^{-1}K)} is the
-posterior variance had *every* cell been observed -- available in closed form
+posterior variance had \emph{every} cell been observed -- available in closed form
 through the Kronecker eigendecomposition, no draws needed. Missing cells
 change the variance only locally, so the draws are spent purely on that
 correction: each zero-mean perturbation draw \eqn{d_{\mathrm{obs}}}
 (Papandreou & Yuille 2010, one CG solve) is paired with an exact
-complete-grid twin \eqn{d_{\mathrm{complete}}} built from the *same* random
+complete-grid twin \eqn{d_{\mathrm{complete}}} built from the \emph{same} random
 numbers \eqn{u, e}, so their difference is nearly noise-free away from gaps
 (a control variate). Modest draw counts therefore give variances that plain
 Monte-Carlo would need hundreds of draws to match, and cells far from any
 gap are essentially exact.
 
 The draws are independent, so they run through
-[future.apply::future_lapply()]: serial under the default
-[future::plan()], parallel when the caller selects a multi-worker plan.
-`future.seed = TRUE` gives every draw its own pre-generated
-L'Ecuyer-CMRG stream, so results are reproducible under [set.seed()] and
+\code{\link[future.apply:future_lapply]{future.apply::future_lapply()}}: serial under the default
+\code{\link[future:plan]{future::plan()}}, parallel when the caller selects a multi-worker plan.
+\code{future.seed = TRUE} gives every draw its own pre-generated
+L'Ecuyer-CMRG stream, so results are reproducible under \code{\link[=set.seed]{set.seed()}} and
 identical for every backend and worker count.
 }
+\keyword{internal}

--- a/man/gp_predict.Rd
+++ b/man/gp_predict.Rd
@@ -20,104 +20,110 @@ gp_predict(
 )
 }
 \arguments{
-\item{obs_data}{Data frame with `id` (site), `t` (time) and a count column
-named by `value` (`NA` where missing). `t` is a numeric time index whose
-*differences* encode real elapsed time, so gaps and uneven spacing between
+\item{obs_data}{Data frame with \code{id} (site), \code{t} (time) and a count column
+named by \code{value} (\code{NA} where missing). \code{t} is a numeric time index whose
+\emph{differences} encode real elapsed time, so gaps and uneven spacing between
 time points are modelled as genuine time distances (use e.g. weeks or days
-since a reference). Must use the same `t` encoding as [infer_kernel_params()].}
+since a reference). Must use the same \code{t} encoding as \code{\link[=infer_kernel_params]{infer_kernel_params()}}.}
 
-\item{coordinates}{Site coordinates (data frame with `id`, `lon`, `lat`).}
+\item{coordinates}{Site coordinates (data frame with \code{id}, \code{lon}, \code{lat}).}
 
-\item{hyperparameters}{A list with elements `length_scale`, `periodic_scale`,
-`long_term_scale`, `nugget_ratio` and `sigma2` -- the value returned by
-[infer_kernel_params()].}
+\item{hyperparameters}{A list with elements \code{length_scale}, \code{periodic_scale},
+\code{long_term_scale}, \code{nugget_ratio} and \code{sigma2} -- the value returned by
+\code{\link[=infer_kernel_params]{infer_kernel_params()}}.}
 
 \item{nt}{Number of time points.}
 
-\item{period}{Period of the seasonal cycle, in the same units as `t`.}
+\item{period}{Period of the seasonal cycle, in the same units as \code{t}.}
 
 \item{n_draws}{Number of paired posterior draws used to estimate the
 missing-data correction to the variance (the prediction interval).
-Controls only the interval, not the mean. Use `0` to return the smooth
+Controls only the interval, not the mean. Use \code{0} to return the smooth
 posterior-mean rate only (one solve, no interval). Because most of the
 variance is computed exactly and the draws only estimate the gap
 correction, modest values (25--100) already give tight intervals.}
 
-\item{r}{Negative-Binomial dispersion for the count interval. If `NULL`
+\item{r}{Negative-Binomial dispersion for the count interval. If \code{NULL}
 (default) it is estimated by method of moments from the observed counts.}
 
-\item{value}{Name of the count column (default `"y_obs"`).}
+\item{value}{Name of the count column (default \code{"y_obs"}).}
 
 \item{standardise}{Logical; standardise the plug-in field per site (default
-`TRUE`), matching [infer_kernel_params()].}
+\code{TRUE}), matching \code{\link[=infer_kernel_params]{infer_kernel_params()}}.}
 
 \item{cg_tol}{Convergence tolerance for the single posterior-mean CG solve
 (the deterministic part of the prediction).}
 
-\item{cg_draw_tol}{Convergence tolerance for the `n_draws` perturbation-draw
-CG solves. Deliberately looser than `cg_tol`: the draws only feed a
+\item{cg_draw_tol}{Convergence tolerance for the \code{n_draws} perturbation-draw
+CG solves. Deliberately looser than \code{cg_tol}: the draws only feed a
 Monte-Carlo variance whose own relative error is
-\eqn{\approx 1/\sqrt{2\,(n_{draws}-1)}} (about 5% at 200 draws), so
-solver error below that is wasted work. At the default `1e-3` the
-posterior sd typically changes by well under 1% relative to a tight solve,
+\eqn{\approx 1/\sqrt{2\,(n_{draws}-1)}} (about 5\% at 200 draws), so
+solver error below that is wasted work. At the default \code{1e-3} the
+posterior sd typically changes by well under 1\% relative to a tight solve,
 while the draw loop needs roughly half the CG iterations.}
 
 \item{progress}{Logical; show a progress bar over the posterior-draw loop
-(the expensive part). Defaults to `TRUE`, but the bar is drawn only in an
+(the expensive part). Defaults to \code{TRUE}, but the bar is drawn only in an
 interactive UTF-8 / truecolor terminal -- it stays silent in scripts,
-knitr, logs and CI. Under a multi-worker [future::plan()] the bar is
-suppressed (workers cannot tick it). Set `FALSE` to disable it entirely.}
+knitr, logs, and CI. Under a multi-worker \code{\link[future:plan]{future::plan()}} the bar is
+suppressed (workers cannot tick it). Set \code{FALSE} to disable it entirely.}
 }
 \value{
-A data frame with one row per cell and columns `id`, `t`, `rate`
-  (posterior point estimate of \eqn{\lambda}), and -- when `n_draws >= 1` --
-  `lower` and `upper` (the 95% count prediction interval). The dispersion `r`
-  used and `n_draws` are attached as attributes.
+A data frame with one row per site-by-time cell (site-week) and
+columns \code{id}, \code{t}, \code{rate}
+(posterior point estimate of \eqn{\lambda}), and -- when \code{n_draws >= 1} --
+\code{lower} and \code{upper} (the 95\% count prediction interval). The dispersion \code{r}
+used and \code{n_draws} are attached as attributes.
 }
 \description{
-Given kernel hyperparameters (e.g. from [infer_kernel_params()]), predicts the
+Given kernel hyperparameters (e.g. from \code{\link[=infer_kernel_params]{infer_kernel_params()}}), predicts the
 latent rate \eqn{\lambda = e^{\mu_s + f_{st}}} at every site-by-time cell by
 conditioning a separable Gaussian process on the observed counts only. The
 posterior mean is obtained from a single matrix-free CG solve (so it is
 smooth and deterministic). The posterior variance splits into an exact
 closed-form "no gaps" part (via the Kronecker eigendecomposition) plus a
-missing-data correction estimated from `n_draws` paired perturbation draws
-(a control variate; see [gp_posterior_var()]), so modest draw counts give
+missing-data correction estimated from \code{n_draws} paired perturbation draws
+(a control variate; see \code{\link[=gp_posterior_var]{gp_posterior_var()}}), so modest draw counts give
 tight intervals. The latent-rate posterior is then combined with
 Negative-Binomial observation noise (law of total variance, lognormal
-moment-match) to give a 95% count prediction interval.
+moment-match) to give a 95\% count prediction interval.
 }
 \details{
 Because the fit conditions on the observed set, missing cells are filled by
 genuine GP interpolation and their prediction interval can widen over gaps --
 unlike a completed-grid smoother that mean-imputes the gaps.
+
+Predictions are made at every \verb{(id, t)} cell present in \code{obs_data}. To
+predict at time points with no data anywhere (e.g. a future week), append
+rows with \code{NA} counts for those times (every site) and increase \code{nt}
+accordingly; the interval widens with distance from the data. Treat
+extrapolation beyond the observed range with the usual caution.
 }
 \section{Parallel execution}{
 
-The `n_draws` perturbation draws are independent CG solves and run through
-the future framework. By default (no [future::plan()] set) they run
+The \code{n_draws} perturbation draws are independent CG solves and run through
+the future framework. By default (no \code{\link[future:plan]{future::plan()}} set) they run
 serially, exactly as before. To spread them across CPU cores, set a plan
 before calling and reset it after:
 
-```r
-future::plan(future::multisession, workers = 4)
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{future::plan(future::multisession, workers = 4)
 pred <- gp_predict(...)
 future::plan(future::sequential)
-```
+}\if{html}{\out{</div>}}
 
 Results are identical for every backend and worker count, and reproducible
-under [set.seed()] (each draw gets its own pre-generated L'Ecuyer-CMRG
-stream). Parallelism pays off when `n * n_draws` is large: each worker
+under \code{\link[=set.seed]{set.seed()}} (each draw gets its own pre-generated L'Ecuyer-CMRG
+stream). Parallelism pays off when \code{n * n_draws} is large: each worker
 costs about a second to start and receives the kernel matrices once. For
 very large site counts you may need to raise
-`options(future.globals.maxSize = ...)` (the matrices shipped to workers
+\code{options(future.globals.maxSize = ...)} (the matrices shipped to workers
 are ~40 MB at 1000 sites x 260 weeks; the default cap is 500 MiB). If R
 uses a multithreaded BLAS (e.g. OpenBLAS/MKL), cap its threads inside
 workers to avoid oversubscription; R's shipped BLAS is single-threaded, so
 by default there is nothing to do. See
-`vignette("parallel", package = "weave")` for a walkthrough.
+\code{vignette("parallel", package = "weave")} for a walkthrough.
 }
 
 \seealso{
-[infer_kernel_params()]
+\code{\link[=infer_kernel_params]{infer_kernel_params()}}
 }

--- a/man/gp_predict.Rd
+++ b/man/gp_predict.Rd
@@ -44,7 +44,12 @@ variance is computed exactly and the draws only estimate the gap
 correction, modest values (25--100) already give tight intervals.}
 
 \item{r}{Negative-Binomial dispersion for the count interval. If \code{NULL}
-(default) it is estimated by method of moments from the observed counts.}
+(default) it is estimated by method of moments from the observed counts.
+\code{Inf} is valid and means Poisson observation noise (no overdispersion);
+the method-of-moments estimate returns \code{Inf} itself when the data show
+no excess variance, so \code{attr(., "r")} on the result can be \code{Inf}. The
+distribution affects only the interval width -- the \code{rate} column does
+not depend on it.}
 
 \item{value}{Name of the count column (default \code{"y_obs"}).}
 

--- a/man/infer_kernel_params.Rd
+++ b/man/infer_kernel_params.Rd
@@ -20,58 +20,59 @@ infer_kernel_params(
 )
 }
 \arguments{
-\item{obs_data}{Data frame with `id` (site), `t` (time) and the count column
-named by `value`. `t` is a numeric time index whose *differences* encode
+\item{obs_data}{Data frame with \code{id} (site), \code{t} (time) and the count column
+named by \code{value}. \code{t} is a numeric time index whose \emph{differences} encode
 real elapsed time, so gaps and uneven spacing between time points are
 modelled as genuine time distances (use e.g. weeks or days since a
-reference). [gp_predict()] must be given the same `t` encoding.}
+reference). \code{\link[=gp_predict]{gp_predict()}} must be given the same \code{t} encoding.}
 
-\item{coordinates}{Site coordinates (data frame with `lon`, `lat`), ordered
-to match `sort(unique(obs_data$id))`.}
+\item{coordinates}{Site coordinates: a data frame with \code{id}, \code{lon}, \code{lat},
+one row per site in \code{obs_data} (rows are matched by \code{id}, so order does
+not matter).}
 
 \item{nt}{Number of time points.}
 
-\item{period}{Period of the seasonal cycle, in the same units as `t`.}
+\item{period}{Period of the seasonal cycle, in the same units as \code{t}.}
 
-\item{value}{Name of the count column (default `"y_obs"`).}
+\item{value}{Name of the count column (default \code{"y_obs"}).}
 
 \item{standardise}{Logical; standardise the plug-in field per site (default
-`TRUE`).}
+\code{TRUE}).}
 
-\item{priors}{Log-normal priors, see [default_kernel_priors()].}
+\item{priors}{Log-normal priors, see \code{\link[=default_kernel_priors]{default_kernel_priors()}}.}
 
 \item{start}{Named/length-4 starting values on the natural scale
-(`length_scale`, `periodic_scale`, `long_term_scale`, `nugget_ratio`).}
+(\code{length_scale}, \code{periodic_scale}, \code{long_term_scale}, \code{nugget_ratio}).}
 
 \item{n_sites}{Optional integer. If supplied and smaller than the number of
 sites, the hyperparameters are estimated from a random subsample of this
 many sites. The kernel hyperparameters are shared, population-level
-quantities, so a representative site subsample estimates the same length
-scales at a fraction of the \eqn{O(n^3)} cost -- useful for very large site
-counts. Default `NULL` uses all sites. The subsample is drawn from the
-current RNG state, so set a seed beforehand (e.g. [set.seed()]) for a
-reproducible estimate. Note: this subsamples *sites* only, not time points
+quantities, so a representative site subsample estimates the same
+length-scales at a fraction of the \eqn{O(n^3)} cost -- useful for very large site
+counts. Default \code{NULL} uses all sites. The subsample is drawn from the
+current RNG state, so set a seed beforehand (e.g. \code{\link[=set.seed]{set.seed()}}) for a
+reproducible estimate. Note: this subsamples \emph{sites} only, not time points
 (the temporal kernel needs the full series to resolve the periodic and
 long-term scales).}
 
-\item{refine}{Logical; if `TRUE`, run `refine_iter` EM-style refinement passes
+\item{refine}{Logical; if \code{TRUE}, run \code{refine_iter} EM-style refinement passes
 that re-fit after filling the gaps with the GP conditional mean (see
-Details). Default `FALSE` (the fast single-pass estimate). Recommended when
+Details). Default \code{FALSE} (the fast single-pass estimate). Recommended when
 missingness is non-trivial.}
 
-\item{refine_iter}{Number of refinement passes when `refine = TRUE` (default
-`3`). Ignored when `refine = FALSE`.}
+\item{refine_iter}{Number of refinement passes when \code{refine = TRUE} (default
+\code{3}). Ignored when \code{refine = FALSE}.}
 }
 \value{
-A list with `length_scale`, `periodic_scale`, `long_term_scale`,
-  `nugget_ratio`, the profiled `sigma2`, the maximised `log_posterior`, and
-  `convergence` (the `optim` code; 0 = success).
+A list with \code{length_scale}, \code{periodic_scale}, \code{long_term_scale},
+\code{nugget_ratio}, the profiled \code{sigma2}, the maximised \code{log_posterior}, and
+\code{convergence} (the \code{optim} code; 0 = success).
 }
 \description{
-Estimates `(length_scale, periodic_scale, long_term_scale)` plus a
+Estimates \verb{(length_scale, periodic_scale, long_term_scale)} plus a
 noise-to-signal ratio by maximising the exact GP marginal likelihood of a
 plug-in latent field, using the Kronecker eigendecomposition so the full
-`(n * nt)`-square covariance is never formed. Fast and deterministic -- no
+\code{(n * nt)}-square covariance is never formed. Fast and deterministic -- no
 MCMC, no iterative solver.
 }
 \details{
@@ -79,11 +80,17 @@ This is the recommended quick estimator when a fast hyperparameter estimate is
 wanted (e.g. as a starting point for a downstream sampler, or as a standalone
 summary).
 
-Set `refine` to enable an EM-style refinement that removes the bias missing
+Strictly, the score maximised is the marginal likelihood \emph{plus} weakly
+informative log-normal priors on the four parameters (a MAP estimate; see
+\code{\link[=default_kernel_priors]{default_kernel_priors()}}). The priors act as mild regularisation that
+keeps weakly identified parameters -- notably \code{long_term_scale} -- away
+from the boundary; pass \code{priors} to change them.
+
+Set \code{refine} to enable an EM-style refinement that removes the bias missing
 cells introduce. Each pass refits after replacing the gaps with the GP
 posterior (conditional) mean under the current estimate -- a correlation-aware
 fill, not the flat mean-imputation -- using the same matrix-free CG solve as
-[gp_predict()]. The expensive observed-cell solve runs only once per pass (not
+\code{\link[=gp_predict]{gp_predict()}}. The expensive observed-cell solve runs only once per pass (not
 inside the optimiser), so it stays cheap, and it typically converges in 2-3
 passes to the estimate you would get with no missing data at all. It does not
 remove the intrinsic plug-in attenuation (conditioning on a noisy field rather

--- a/man/kron_mv.Rd
+++ b/man/kron_mv.Rd
@@ -2,28 +2,30 @@
 % Please edit documentation in R/cg.R
 \name{kron_mv}
 \alias{kron_mv}
-\title{Fast Kronecker–product matrix–vector multiply (times vary fastest)}
+\title{Fast Kronecker-product matrix-vector multiply (times vary fastest)}
 \usage{
 kron_mv(v, space, time)
 }
 \arguments{
-\item{v}{Numeric vector of length `nrow(space) * nrow(time)`, ordered with
+\item{v}{Numeric vector of length \code{nrow(space) * nrow(time)}, ordered with
 times varying fastest within site.}
 
 \item{space}{Spatial kernel matrix (size \eqn{n \times n}). Must be
 symmetric (kernels are, by construction) -- the implementation relies on
-`t(space) == space`.}
+\code{t(space) == space}.}
 
 \item{time}{Temporal kernel matrix (size \eqn{nt \times nt}).}
 }
 \value{
-A numeric vector the same length as `v`.
+A numeric vector the same length as \code{v}.
 }
 \description{
-In plain terms: multiplies a big covariance `K = space ⊗ time` by a vector
-without ever forming `K`, using a reshape–multiply–reshape trick.
+In plain terms: multiplies a big covariance
+\eqn{K = \mathrm{space} \otimes \mathrm{time}} by a vector without ever
+forming \code{K}, using a reshape-multiply-reshape trick.
 }
 \details{
-Technically: for \eqn{v = \mathrm{vec}(X^\top)} with `times` varying fastest,
+Technically: for \eqn{v = \mathrm{vec}(X^\top)} with \code{times} varying fastest,
 computes \eqn{(space \otimes time)\,v = \mathrm{vec}\!\big((space\,X\,time^\top)^\top\big)}.
 }
+\keyword{internal}

--- a/man/periodic_kernel.Rd
+++ b/man/periodic_kernel.Rd
@@ -9,13 +9,16 @@ periodic_kernel(x, alpha, period)
 \arguments{
 \item{x}{A numeric vector or matrix of distances.}
 
-\item{alpha}{A positive numeric scalar controlling the amplitude.}
+\item{alpha}{A positive numeric scalar controlling how sharply correlation
+falls within each cycle: smaller values allow sharp seasonal peaks;
+larger values give a gentler, smoother cycle.}
 
-\item{period}{A positive numeric scalar giving the period.}
+\item{period}{A positive numeric scalar giving the period \eqn{p}.}
 }
 \value{
 A numeric vector or matrix of periodic kernel values.
 }
 \description{
-Computes a periodic kernel for a distance vector or matrix.
+Computes a periodic kernel for a distance vector or matrix:
+\deqn{k(d) = \exp\left(-\frac{2\sin^2(\pi d / p)}{\alpha^2}\right).}
 }

--- a/man/quick_mvnorm.Rd
+++ b/man/quick_mvnorm.Rd
@@ -2,18 +2,28 @@
 % Please edit documentation in R/sample.R
 \name{quick_mvnorm}
 \alias{quick_mvnorm}
-\title{Quick multivariate normal samples over two dimensions}
+\title{Quick multivariate normal draw over two dimensions}
 \usage{
 quick_mvnorm(space, time)
 }
 \arguments{
-\item{space}{Space kernel matrix}
+\item{space}{Space kernel matrix.}
 
-\item{time}{Time kernel matrix}
+\item{time}{Time kernel matrix.}
+}
+\value{
+A numeric vector of length \code{nrow(space) * nrow(time)}, ordered
+site by site with time varying fastest (matching
+\code{kronecker(space, time)}).
 }
 \description{
-This is equivalent to estimating the full spatio-temporal covariance matrix
-and sampling from the multivariate normal distribution:
-full_k <- kronecker(dist_k, time_k)
-f  <- mvrnorm(1, rep(0, n * nt), full_k)
+Draws one sample from a zero-mean Gaussian with separable space-time
+covariance, without ever forming the full matrix. This is equivalent to
+forming the full spatio-temporal covariance and drawing from the
+multivariate normal distribution:
+}
+\details{
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{full_k <- kronecker(space, time)
+f <- MASS::mvrnorm(1, rep(0, nrow(space) * nrow(time)), full_k)
+}\if{html}{\out{</div>}}
 }

--- a/man/quick_mvnorm_chol.Rd
+++ b/man/quick_mvnorm_chol.Rd
@@ -2,18 +2,25 @@
 % Please edit documentation in R/sample.R
 \name{quick_mvnorm_chol}
 \alias{quick_mvnorm_chol}
-\title{Quick multivariate normal samples over two dimensions (cholesky precomputed)}
+\title{Quick multivariate normal draw over two dimensions (Cholesky precomputed)}
 \usage{
 quick_mvnorm_chol(space_chol, time_chol)
 }
 \arguments{
-\item{space_chol}{Cholesky decomposition of sapace kernel matrix}
+\item{space_chol}{Upper-triangular Cholesky factor of the space kernel
+matrix, as returned by \code{\link[=chol]{chol()}}. Passing the lower-triangular factor
+gives silently wrong draws.}
 
-\item{time_chol}{Cholesky decomposition of time kernel matrix}
+\item{time_chol}{Upper-triangular Cholesky factor of the time kernel
+matrix, as returned by \code{\link[=chol]{chol()}}.}
+}
+\value{
+A numeric vector of length \code{nrow(space_chol) * nrow(time_chol)},
+ordered site by site with time varying fastest (matching
+\code{kronecker(space, time)}).
 }
 \description{
-This is equivalent to estimating the full spatio-temporal covariance matrix
-and sampling from the multivariate normal distribution:
-full_k <- kronecker(dist_k, time_k)
-f  <- mvrnorm(1, rep(0, n * nt), full_k)
+As \code{\link[=quick_mvnorm]{quick_mvnorm()}}, but taking precomputed Cholesky factors so repeated
+draws (e.g. the perturbation draws in \code{\link[=gp_predict]{gp_predict()}}) skip the
+factorisation cost.
 }

--- a/man/rbf_kernel.Rd
+++ b/man/rbf_kernel.Rd
@@ -9,12 +9,17 @@ rbf_kernel(x, theta)
 \arguments{
 \item{x}{A numeric vector or matrix of distances.}
 
-\item{theta}{A positive numeric scalar giving the length-scale parameter.}
+\item{theta}{A positive numeric scalar giving the length-scale parameter
+(the \eqn{\ell} of textbook presentations): correlation decays with
+distance over this scale, so larger values give smoother functions.}
 }
 \value{
 A numeric vector or matrix with RBF kernel values.
 }
 \description{
 Computes the radial basis function (RBF) kernel for a distance vector
-or matrix.
+or matrix:
+\deqn{k(d) = \exp\left(-\frac{d^2}{2\theta^2}\right).}
+This is the correlation form of the kernel (\eqn{k(0) = 1}); any global
+variance is applied separately.
 }

--- a/man/space_kernel.Rd
+++ b/man/space_kernel.Rd
@@ -2,22 +2,24 @@
 % Please edit documentation in R/kernel.R
 \name{space_kernel}
 \alias{space_kernel}
-\title{Estimate the spatial kernel}
+\title{Build the spatial correlation matrix}
 \usage{
 space_kernel(coordinates, length_scale, nugget = 1e-09)
 }
 \arguments{
-\item{coordinates}{A data frame with columns `lon` and `lat` in degrees.}
+\item{coordinates}{A data frame with columns \code{lon} and \code{lat}.}
 
-\item{length_scale}{A positive numeric scalar for the spatial length scale.}
+\item{length_scale}{A positive numeric scalar for the spatial length-scale.}
 
 \item{nugget}{A non-negative numeric scalar added to the diagonal for
 numerical stability.}
 }
 \value{
-A positive-definite matrix representing spatial covariance.
+A positive-definite matrix representing spatial correlation.
 }
 \description{
-Builds a spatial covariance matrix using an RBF kernel with a nugget
-term for numerical stability.
+Builds a spatial correlation matrix using an RBF kernel with a nugget
+term for numerical stability. Distances are Euclidean in the coordinate
+units (see \code{\link[=get_spatial_distance]{get_spatial_distance()}}), so \code{length_scale} is in those same
+units.
 }

--- a/man/time_kernel.Rd
+++ b/man/time_kernel.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/kernel.R
 \name{time_kernel}
 \alias{time_kernel}
-\title{Estimate the temporal kernel}
+\title{Build the temporal correlation matrix}
 \usage{
 time_kernel(
   times,
@@ -15,22 +15,23 @@ time_kernel(
 \arguments{
 \item{times}{A numeric vector of time indices.}
 
-\item{periodic_scale}{A positive numeric scalar controlling the periodic
-variation.}
+\item{periodic_scale}{A positive numeric scalar controlling how sharply
+correlation falls within each seasonal cycle: smaller values allow sharp
+seasonal peaks; larger values give a gentler, smoother cycle.}
 
-\item{long_term_scale}{A positive numeric scalar for the long-term length
-scale.}
+\item{long_term_scale}{A positive numeric scalar for the long-term
+length-scale.}
 
 \item{nugget}{A non-negative numeric scalar added to the diagonal for
 numerical stability.}
 
 \item{period}{A positive numeric scalar giving the period of the seasonal
-component.}
+component, in the same units as \code{times}.}
 }
 \value{
-A positive-definite matrix representing temporal covariance.
+A positive-definite matrix representing temporal correlation.
 }
 \description{
-Builds a temporal covariance matrix by combining periodic and
+Builds a temporal correlation matrix by combining periodic and
 long-term RBF components with a nugget term for numerical stability.
 }

--- a/vignettes/data-preparation.Rmd
+++ b/vignettes/data-preparation.Rmd
@@ -1,0 +1,157 @@
+---
+title: "Using weave with your own data"
+output:
+  rmarkdown::html_vignette:
+    css: weave.css
+    toc: true
+    toc_depth: 2
+vignette: >
+  %\VignetteIndexEntry{Using weave with your own data}
+  %\VignetteEncoding{UTF-8}
+  %\VignetteEngine{knitr::rmarkdown}
+editor_options:
+  markdown:
+    wrap: 72
+---
+
+```{r, include = FALSE}
+source("_common.R")
+set.seed(20260707)
+```
+
+```{r setup}
+library(weave)
+```
+
+The [walkthrough](walkthrough.html) works on simulated data that arrives in
+exactly the shape the model functions expect. Real data rarely does. This
+article covers the practical on-ramp: preparing a raw data frame with
+`data_process()`, encoding time correctly, what the coordinates mean, and how
+to predict beyond the weeks you observed.
+
+## 1. From a raw data frame to model-ready inputs
+
+`infer_kernel_params()` and `gp_predict()` need two objects:
+
+* `obs_data` — one row per site-week, with a factor `id`, a numeric time
+  `t`, and the count `y_obs` (`NA` where missing);
+* `coordinates` — one row per site, with `id`, `lon`, `lat`.
+
+`data_process()` builds both from a single raw data frame. It expects columns
+`t` (time), `n` (the count), `lat` and `lon`, plus any columns that together
+identify a site — passed as bare names:
+
+```{r raw-data}
+# a raw extract: two regions, facilities reporting weekly counts, some weeks
+# absent entirely (never recorded) and note facility C only starts at week 4
+raw <- data.frame(
+  region   = rep(c("North", "North", "South"), each = 6),
+  facility = rep(c("A", "B", "C"), each = 6),
+  t        = c(1:6,  1:6,  4:9),
+  n        = rpois(18, 20),
+  lat      = rep(c(0.10, 0.15, 0.90), each = 6),
+  lon      = rep(c(0.20, 0.25, 0.80), each = 6)
+)
+raw <- raw[-c(3, 9), ]   # drop two site-weeks entirely, as real data does
+
+prepared <- data_process(raw, region, facility)
+str(prepared, max.level = 1)
+```
+
+Three things happened:
+
+```{r prepared}
+head(prepared$obs_data)
+prepared$coordinates
+prepared$nt
+```
+
+* the site-by-time grid was **completed** — every site now has a row for
+  every time point that appears *anywhere* in the data, with `y_obs = NA`
+  where nothing was recorded (absent rows and `NA` counts are treated
+  identically: as missing). A week recorded by *no* site at all — week 3
+  above — simply stays out of the grid: the kernels measure real elapsed
+  time from `t`, so it is still modelled as a genuine gap;
+* each site got a factor `id` (the original identifying columns are kept);
+* sites that cannot be modelled — all counts missing, or missing
+  coordinates — are dropped, with a message telling you which
+  (`drop_zero = TRUE` also drops sites whose counts are all zero).
+
+The returned pieces feed straight into the two model calls:
+
+```{r fit, eval = FALSE}
+est <- infer_kernel_params(prepared$obs_data, prepared$coordinates,
+                           nt = prepared$nt, period = 52, refine = TRUE)
+pred <- gp_predict(prepared$obs_data, prepared$coordinates,
+                   hyperparameters = est, nt = prepared$nt, period = 52)
+```
+
+## 2. Encoding time correctly
+
+`t` is not just a label: its *differences* are the distances the temporal
+kernel sees. Three rules keep it honest:
+
+* **Use a numeric index whose steps mirror real elapsed time** — e.g. weeks
+  since the first week of the series (`1, 2, 3, ...` for consecutive weeks),
+  or days since a reference date. A fortnight-long gap between two reports
+  should show up as a difference of 2 weeks, not 1 row.
+* **Never use an index that resets**, like week-of-year: week 52 of one year
+  and week 1 of the next would look 51 weeks apart instead of adjacent.
+* **`period` is in the same units as `t`** — weekly data with a yearly
+  season means `period = 52`; daily data means `period = 365.25`.
+
+Uneven spacing is fine — monthly data, or a mix of reporting frequencies,
+just needs `t` values whose gaps reflect the real calendar. Both
+`infer_kernel_params()` and `gp_predict()` must be given the *same* `t`
+encoding, since the hyperparameters are estimated on that axis.
+
+## 3. What the coordinates mean
+
+Spatial distance is plain **Euclidean distance in the units of `lon`/`lat`**
+— there is no great-circle correction. Two consequences:
+
+* the fitted `length_scale` is in those units (degrees, if you pass raw
+  longitude/latitude);
+* one degree of longitude shrinks with latitude, so for a large study area
+  or one far from the equator, **project the coordinates first** (e.g. to
+  kilometres with a suitable local projection) and interpret `length_scale`
+  in km.
+
+For the small, near-equatorial extents typical of a single country or
+region, raw degrees are usually an acceptable approximation.
+
+## 4. Predicting beyond the observed weeks
+
+`gp_predict()` predicts at every `(id, t)` cell present in `obs_data`. To
+get predictions for weeks with no data anywhere — filling the future, or a
+gap before the series starts — append rows with `NA` counts for those weeks
+(for every site) and increase `nt` to match:
+
+```{r forecast, eval = FALSE}
+obs <- prepared$obs_data
+future_weeks <- (max(obs$t) + 1):(max(obs$t) + 8)      # 8 weeks ahead
+extra <- expand.grid(id = levels(obs$id), t = future_weeks)
+extra$y_obs <- NA
+
+obs_extended <- rbind(obs[, c("id", "t", "y_obs")], extra)
+nt_extended  <- length(unique(obs_extended$t))
+
+pred <- gp_predict(obs_extended, prepared$coordinates, hyperparameters = est,
+                   nt = nt_extended, period = 52)
+```
+
+The prediction interval widens with distance from the data, as it should.
+Treat genuine extrapolation with the usual caution: beyond the observed
+range the GP leans increasingly on the fitted seasonal shape and long-term
+drift rather than on evidence.
+
+## 5. Scaling up
+
+* **Estimation** costs \( O(n^3 + n_t^3) \) in the site and time counts. For
+  very large site counts, pass `n_sites` to `infer_kernel_params()`: the
+  hyperparameters are shared, population-level quantities, so a random site
+  subsample estimates the same values at a fraction of the cost (set a seed
+  first for reproducibility; time points are never subsampled).
+* **Prediction** cost is dominated by the interval draws, which parallelise
+  across CPU cores with one line of setup — see
+  [*Running predictions in parallel*](parallel.html).

--- a/vignettes/data-preparation.Rmd
+++ b/vignettes/data-preparation.Rmd
@@ -39,7 +39,13 @@ to predict beyond the weeks you observed.
 
 `data_process()` builds both from a single raw data frame. It expects columns
 `t` (time), `n` (the count), `lat` and `lon`, plus any columns that together
-identify a site — passed as bare names:
+identify a site — passed as bare names.
+
+The counts should be **non-negative integers** (`NA` where missing). The
+observation model is Negative-Binomial — reducing automatically to Poisson
+when the data show no overdispersion — but the distribution only shapes the
+prediction *interval*; the fitted hyperparameters and the predicted rate come
+from a Gaussian model of `log(1 + y)` and are insensitive to it.
 
 ```{r raw-data}
 # a raw extract: two regions, facilities reporting weekly counts, some weeks

--- a/vignettes/gaussian-processes.Rmd
+++ b/vignettes/gaussian-processes.Rmd
@@ -127,7 +127,7 @@ The correlation as a function of separation in time is simply the kernel
 evaluated against distance. A longer length-scale keeps points correlated
 over a wider gap:
 
-```{r kernel-curve, echo = FALSE}
+```{r kernel-curve, echo = FALSE, fig.alt = "Two curves of correlation against separation in time: a short length-scale decays quickly, a long one keeps distant days correlated"}
 lag <- 0:120
 curves <- rbind(
   data.frame(lag = lag, correlation = rbf_kernel(lag, theta = 10),
@@ -135,10 +135,12 @@ curves <- rbind(
   data.frame(lag = lag, correlation = rbf_kernel(lag, theta = 40),
              length_scale = "long (ℓ = 40)")
 )
+curves$length_scale <- factor(curves$length_scale,
+                              levels = c("short (ℓ = 10)", "long (ℓ = 40)"))
 
 ggplot(curves, aes(lag, correlation, colour = length_scale)) +
   geom_line(linewidth = 1.1) +
-  scale_colour_manual(values = unname(weave_pal[c("magenta", "blue")]), name = NULL) +
+  scale_colour_manual(values = unname(weave_pal[c("violet", "green")]), name = NULL) +
   labs(x = "Separation in time (days)", y = "Correlation",
        title = "The RBF kernel: correlation fades with distance",
        subtitle = "A longer length-scale keeps distant days correlated") +
@@ -171,11 +173,14 @@ K_long   <- rbf_kernel(time_dist, theta = 40) + diag(1e-9, length(times))
 With a short length-scale the draws are rough and turn over quickly; with a
 long one they are smooth and slow:
 
-```{r prior-draws-rbf, echo = FALSE, fig.height = 5.2}
+```{r prior-draws-rbf, echo = FALSE, fig.height = 5.2, fig.alt = "Two panels of GP prior draws: rough, rapidly varying curves under a short length-scale; smooth, slowly varying curves under a long one"}
 prior_draws <- rbind(
   cbind(draw_gp(K_short), world = "Short length-scale (rapid change)"),
   cbind(draw_gp(K_long),  world = "Long length-scale (gradual change)")
 )
+prior_draws$world <- factor(prior_draws$world,
+                            levels = c("Short length-scale (rapid change)",
+                                       "Long length-scale (gradual change)"))
 
 ggplot(prior_draws, aes(day, value, colour = draw)) +
   geom_line(linewidth = 0.7, alpha = 0.9) +
@@ -202,7 +207,7 @@ where \( p \) is the period (say 52 weeks) and \( \alpha \) controls how
 sharply the function rises and falls within each cycle. Draws from a periodic
 GP repeat their shape from one cycle to the next:
 
-```{r prior-draws-periodic, echo = FALSE, fig.height = 3.8}
+```{r prior-draws-periodic, echo = FALSE, fig.height = 3.8, fig.alt = "Draws from a periodic GP: each curve repeats the same shape every 52-week cycle"}
 weeks     <- 1:156                                  # three years
 week_dist <- get_temporal_distance(weeks)
 K_season  <- periodic_kernel(week_dist, alpha = 1.2, period = 52) +
@@ -227,7 +232,7 @@ seasonal cycle is present every year but is free to drift slowly in amplitude
 and level over the long run. The package's `time_kernel()` builds exactly this
 combination:
 
-```{r time-kernel, echo = FALSE, fig.height = 3.8}
+```{r time-kernel, echo = FALSE, fig.height = 3.8, fig.alt = "Draws from the product of a periodic kernel and a long-term RBF: seasonal cycles whose amplitude and level drift slowly across years"}
 K_time <- time_kernel(weeks, periodic_scale = 1.2, long_term_scale = 120,
                       period = 52)
 
@@ -244,8 +249,10 @@ ggplot(draw_gp(K_time, 5), aes(day, value, colour = draw)) +
 In space, `weave` uses an RBF kernel on the distance between sites, so nearby
 facilities are expected to behave alike. Space and time are then combined into
 a single space-time covariance with a *separable* structure,
-\( K_{\text{space}} \otimes K_{\text{time}} \), which keeps the model fast — a
-point the [walkthrough](walkthrough.html) returns to. Three numbers control
+\( K_{\text{space}} \otimes K_{\text{time}} \) — the *Kronecker product*, a
+recipe that builds the one enormous space-time matrix from the two small
+ones — which keeps the model fast, a point the
+[walkthrough](walkthrough.html) returns to. Three numbers control
 all of this: the spatial `length_scale`, the `periodic_scale`, and the
 `long_term_scale`. Estimating them from data is the subject of that article.
 
@@ -280,26 +287,31 @@ have to tell it to.
 Let us condition on a handful of noisy feeder counts. For this illustration we
 treat the counts as continuous measurements and leave the count-specific
 machinery to the walkthrough. Note the deliberate gap in the observations
-between days 25 and 55.
+between days 25 and 55. (In the package, `rbf_kernel()`'s `theta` argument is
+the length-scale \( \ell \), and the kernel is returned in correlation form —
+\( \sigma^2 = 1 \).)
 
 ```{r posterior-demo}
 # a smooth underlying pattern we pretend not to know
 true_fn <- function(x) 12 + 6 * sin(x / 12)
 
+set.seed(1)                                        # reproducible noise
 x_obs <- c(3, 8, 14, 20, 25, 55, 62, 70, 78, 85)   # note the gap 25 -> 55
 y_obs <- true_fn(x_obs) + rnorm(length(x_obs), sd = 1.2)
 
-x_star <- seq(0, 90, length.out = 200)
+x_star  <- seq(0, 90, length.out = 200)
 ell     <- 12      # length-scale
+sigma_f <- 4       # signal sd: how far the function can range from its mean
 sigma_n <- 1.2     # observation noise
 
 # RBF kernel between two sets of inputs, via outer-difference distances
+# (rbf_kernel() returns the correlation form, so we scale by sigma_f^2)
 rbf <- function(a, b, theta) rbf_kernel(outer(a, b, "-"), theta = theta)
 
 ybar <- mean(y_obs)                                # model the centred data
-Kxx  <- rbf(x_obs,  x_obs,  ell) + sigma_n^2 * diag(length(x_obs))
-Ksx  <- rbf(x_star, x_obs,  ell)
-Kss  <- rbf(x_star, x_star, ell)
+Kxx  <- sigma_f^2 * rbf(x_obs,  x_obs,  ell) + sigma_n^2 * diag(length(x_obs))
+Ksx  <- sigma_f^2 * rbf(x_star, x_obs,  ell)
+Kss  <- sigma_f^2 * rbf(x_star, x_star, ell)
 
 Kxx_inv  <- solve(Kxx)
 post_mean <- ybar + Ksx %*% Kxx_inv %*% (y_obs - ybar)          # posterior mean
@@ -318,19 +330,20 @@ The posterior mean threads through the observations, and the 95% band
 tightens where data is plentiful and balloons across the gap — an honest
 admission that the feeder count there is genuinely uncertain.
 
-```{r posterior-plot, echo = FALSE}
+```{r posterior-plot, echo = FALSE, fig.alt = "GP posterior mean with a 95% band through noisy points; the band is narrow near observations and balloons over the observation gap, still covering the dashed hidden truth"}
 ggplot() +
   geom_ribbon(data = post, aes(x, ymin = lower, ymax = upper),
               fill = weave_cols[["prediction"]], alpha = 0.18) +
   geom_line(data = data.frame(x = x_star, y = true_fn(x_star)),
-            aes(x, y), colour = "grey55", linetype = "dashed", linewidth = 0.6) +
+            aes(x, y), colour = weave_cols[["truth"]], linetype = "dashed",
+            linewidth = 0.6) +
   geom_line(data = post, aes(x, mean),
             colour = weave_cols[["prediction"]], linewidth = 1) +
   geom_point(data = data.frame(x = x_obs, y = y_obs), aes(x, y),
-             colour = weave_cols[["truth"]], size = 2.2) +
+             colour = weave_cols[["observed"]], size = 2.2) +
   labs(x = "Day", y = "Hummingbird visits",
        title = "Posterior: best guess with honest uncertainty",
-       subtitle = "points = observations, blue = posterior mean + 95% band, dashed = hidden truth") +
+       subtitle = "grey = observations · blue = mean + 95% band · navy dashed = truth") +
   theme_weave()
 ```
 
@@ -347,7 +360,7 @@ With the intuition in place, the [walkthrough](walkthrough.html) shows how
 
 1. **estimates** the three kernel length-scales directly from observed counts,
    by maximising the Gaussian-process marginal likelihood; and
-2. **predicts** the underlying rate at every facility and week — filling in
+2. **predicts** the underlying rate at every site and week — filling in
    missing weeks and attaching a 95% prediction interval — with
    `gp_predict()`.
 

--- a/vignettes/parallel.Rmd
+++ b/vignettes/parallel.Rmd
@@ -16,13 +16,17 @@ editor_options:
 source("_common.R")
 ```
 
-The expensive part of `gp_predict()` is the set of `n_draws` perturbation
-draws that estimate how the missing weeks widen the prediction interval. Each
-draw is an independent conjugate-gradient solve, so at scale (many sites,
-many draws) they parallelise naturally across CPU cores.
+This short article continues the example from
+[the walkthrough](walkthrough.html) — `obs_data` and `est` below are the
+data and fitted hyperparameters built there.
 
-weave uses the [future](https://future.futureverse.org/) framework for this.
-By default everything runs serially — nothing to install, nothing to
+The expensive part of `gp_predict()` is the set of `n_draws` simulation
+draws that estimate how the missing weeks widen the prediction interval.
+Each draw is an independent solve, so at scale (many sites, many draws) they
+parallelise naturally across CPU cores.
+
+`weave` uses the [future](https://future.futureverse.org/) framework for
+this. By default everything runs serially — nothing to install, nothing to
 configure — and you opt in with a single line before the call. No arguments
 to `gp_predict()` change.
 
@@ -52,9 +56,9 @@ Parallelism is purely a speed decision:
 
 ## When it pays off
 
-Each worker takes about a second to start, and receives the kernel matrices
-once. Parallelism therefore helps when `sites × draws` is large; for small
-problems the serial default is already the fastest option. As an indication:
+Each worker takes about a second to start and receives the kernel matrices
+once. Parallelism therefore helps when the number of sites × draws is large;
+for small problems the serial default is already the fastest option. As an indication:
 a 300-site × 260-week problem with 10% missing data and 100 draws ran about
 4× faster with `workers = 4` on a 4-performance-core laptop.
 

--- a/vignettes/walkthrough.Rmd
+++ b/vignettes/walkthrough.Rmd
@@ -149,6 +149,39 @@ obs_data  <- observed_data(true_data)
 cat(sprintf("%.0f%% of weeks are missing\n", 100 * mean(is.na(obs_data$y_obs))))
 ```
 
+::: {.caveat}
+Two things the simulation glosses over for real data. First, `t` must be a
+numeric index whose *differences* encode real elapsed time — e.g. weeks since
+a reference date — and `period` must be in those same units; arbitrary
+indices (week-of-year that resets, row numbers) silently distort every
+temporal length-scale. Second, real data rarely arrives in this shape:
+`data_process()` turns one raw data frame into the `obs_data`, `coordinates`
+and `nt` used below — see
+[*Using weave with your own data*](data-preparation.html).
+:::
+
+The gaps are not scattered at random: they arrive in *clustered runs*, the
+way real reporting drops out — a facility goes quiet for a stretch, then
+comes back. Magenta marks the missing weeks:
+
+```{r missingness-map, echo = FALSE, fig.height = 3.8, fig.alt = "Heatmap of sites by weeks: observed weeks in grey, missing weeks in magenta, with the missing weeks forming horizontal clustered runs within sites"}
+miss_map <- data.frame(
+  id      = as.integer(obs_data$id),
+  t       = obs_data$t,
+  status  = ifelse(is.na(obs_data$y_obs), "missing", "observed")
+)
+ggplot(miss_map, aes(t, id, fill = status)) +
+  geom_tile() +
+  scale_fill_manual(values = c(observed = "grey85",
+                               missing = weave_cols[["held_out"]]),
+                    name = NULL) +
+  scale_y_continuous(breaks = seq(5, n, by = 5)) +
+  labs(x = "Week", y = "Site",
+       title = "Where the gaps are",
+       subtitle = "missing weeks (magenta) come in clustered runs, like real reporting dropouts") +
+  theme_weave()
+```
+
 Here are the first four sites. The **navy line** is the true underlying mean
 (\( \lambda = e^{\mu_s + f_{st}} \)); **grey points** are the counts we
 actually observe; and **magenta points** are the *held-out truth* at the weeks
@@ -181,7 +214,7 @@ ggplot() +
   theme_weave()
 ```
 
-## 2. Step 1 — a quick "plug-in" latent field
+## 2. A quick "plug-in" latent field
 
 ::: {.maths}
 We cannot see the latent field \( f \) directly, so we build a cheap stand-in
@@ -227,13 +260,16 @@ plot_df <- rbind(
 )
 ggplot(plot_df, aes(t, value, colour = type)) +
   geom_line(linewidth = 0.8) +
-  scale_colour_manual(values = unname(weave_pal[c("violet", "blue")]), name = NULL) +
+  scale_colour_manual(values = c("true f (scaled)" = weave_cols[["truth"]],
+                                 "plug-in g" = weave_cols[["estimate"]]),
+                      name = NULL) +
   labs(x = "Week", y = "Standardised latent field",
-       title = "Site 1: plug-in field vs the truth") +
+       title = "Site 1: plug-in field vs the truth",
+       subtitle = "navy = true latent field · blue = plug-in estimate") +
   theme_weave()
 ```
 
-## 3. Step 2 — score a set of knobs with the marginal likelihood
+## 3. Score the knobs with the marginal likelihood
 
 ::: {.maths}
 For a candidate set of hyperparameters \( \theta \) the kernels give a
@@ -244,8 +280,9 @@ and a global variance \( \sigma^2 \):
 g \sim \mathcal{N}\!\Big(0,\ \sigma^2\big[(R_{\text{space}} \otimes R_{\text{time}}) + \eta I\big]\Big),
 \]
 
-where \( R \) are *correlation* kernels (unit diagonal). The score for
-\( \theta \) is the log marginal likelihood
+where \( R \) are *correlation* kernels (unit diagonal). Writing \( K \) for
+this whole covariance and \( N = n \cdot n_t \) for the number of cells, the
+score for \( \theta \) is the log marginal likelihood
 
 \[
 \log p(g \mid \theta) = -\tfrac{1}{2}\Big(\log|K| + g^\top K^{-1} g + N\log 2\pi\Big).
@@ -253,6 +290,11 @@ where \( R \) are *correlation* kernels (unit diagonal). The score for
 
 We pick the \( \theta \) that maximises this. The variance \( \sigma^2 \) has a
 closed-form optimum, so we "profile" it out and never search over it.
+
+Strictly, the score also includes weakly informative log-normal priors on the
+four parameters (`default_kernel_priors()`), so the estimate is a MAP rather
+than a pure maximum likelihood — mild regularisation that keeps weakly
+identified parameters (notably `long_term_scale`) off the boundary.
 :::
 
 ::: {.intuition}
@@ -267,7 +309,7 @@ kernel would have to explain the noisy plug-in field with smoothness alone,
 badly distorting the length-scales.
 :::
 
-## 4. Step 3 — why it is fast: the Kronecker trick
+## 4. Why it is fast: the Kronecker trick
 
 ::: {.maths}
 The full covariance is \( (n \cdot n_t) \times (n \cdot n_t) \) — here
@@ -277,8 +319,10 @@ eigendecomposing the *small* factors
 \( R_{\text{time}} = U_t \Lambda_t U_t^\top \) (size \( n_t \)) is enough:
 
 \[
-\log|K + \eta I| = \sum_{i,j} \log(a_i b_j + \eta), \qquad
-g^\top (K + \eta I)^{-1} g = \sum_{i,j} \frac{G_{ij}^2}{a_i b_j + \eta},
+\log\bigl|R_{\text{space}} \otimes R_{\text{time}} + \eta I\bigr|
+  = \sum_{i,j} \log(a_i b_j + \eta), \qquad
+g^\top \bigl(R_{\text{space}} \otimes R_{\text{time}} + \eta I\bigr)^{-1} g
+  = \sum_{i,j} \frac{G_{ij}^2}{a_i b_j + \eta},
 \]
 
 with \( a_i, b_j \) the eigenvalues, \( G = U_s^\top F U_t \), and \( F \) the
@@ -293,7 +337,39 @@ of one enormous matrix we juggle two small ones — one for space, one for time
 the estimate takes a second rather than hours.
 :::
 
-## 5. Step 4 — fit, and check against the truth
+The structure is easiest to see. Below is the full space-time covariance for
+a toy problem of 3 sites × 8 weeks: a 24 × 24 matrix, but built entirely from
+a 3 × 3 spatial kernel and an 8 × 8 temporal one. Each 8 × 8 block is the
+temporal kernel scaled by one entry of the spatial kernel — the whole matrix
+never needs to exist:
+
+```{r kron-schematic, echo = FALSE, fig.height = 4.4, fig.alt = "Heatmap of a 24-by-24 Kronecker-product covariance matrix showing a 3-by-3 grid of 8-by-8 blocks; each block is the temporal kernel scaled by one spatial kernel entry"}
+n_toy <- 3; nt_toy <- 8
+coords_toy <- data.frame(id = 1:n_toy, lon = c(0, 1, 4), lat = c(0, 1, 0))
+Ks_toy <- space_kernel(coords_toy, length_scale = 2)
+Kt_toy <- time_kernel(1:nt_toy, periodic_scale = 1, long_term_scale = 50,
+                      period = 8)
+K_toy  <- kronecker(Ks_toy, Kt_toy)
+
+kron_df <- expand.grid(row = 1:(n_toy * nt_toy), col = 1:(n_toy * nt_toy))
+kron_df$value <- as.vector(K_toy)
+
+ggplot(kron_df, aes(col, row, fill = value)) +
+  geom_tile() +
+  geom_hline(yintercept = c(8.5, 16.5), colour = "white", linewidth = 0.8) +
+  geom_vline(xintercept = c(8.5, 16.5), colour = "white", linewidth = 0.8) +
+  scale_y_reverse() +
+  scale_fill_gradient(low = "#f7f1e8", high = weave_cols[["prediction"]],
+                      name = "covariance") +
+  coord_fixed() +
+  labs(x = NULL, y = NULL,
+       title = "The full covariance for 3 sites × 8 weeks",
+       subtitle = "each 8×8 block = temporal kernel × one spatial kernel entry") +
+  theme_weave() +
+  theme(axis.text = element_blank(), panel.grid.major = element_blank())
+```
+
+## 5. Fit, and check against the truth
 
 `infer_kernel_params()` does all of the above: build the plug-in field, then
 maximise the marginal likelihood over the three length-scales plus the nugget
@@ -311,7 +387,8 @@ two steps:
 
 - **E-step.** With the current hyperparameters, replace each missing week by its
   expected value under the model — the GP **conditional mean** given the weeks we
-  *did* observe (the same kriging solve `gp_predict()` performs).
+  *did* observe (the same conditional-mean solve `gp_predict()` performs;
+  "kriging", in geostatistics jargon).
 - **M-step.** Treat that completed grid as if it were fully observed and
   re-maximise the fast (Kronecker) marginal likelihood to get updated
   hyperparameters.
@@ -324,7 +401,7 @@ cause; the residual plug-in attenuation below — from conditioning on a noisy
 field rather than integrating it out — is a separate matter it does not fix.)
 :::
 
-```{r infer}
+```{r infer, warning = TRUE}
 # maximise the GP marginal likelihood to recover the three length-scales
 # (plus a noise/nugget ratio); the global variance sigma^2 is profiled out.
 # refine = TRUE fills the gaps with the GP conditional mean and refits, removing
@@ -344,7 +421,21 @@ data.frame(
 # the other two pieces estimation returns: the nugget and the profiled variance
 cat(sprintf("nugget ratio (noise/signal) = %.2f;  profiled sigma^2 = %.2f\n",
             est$nugget_ratio, est$sigma2))
+
+# est also carries the maximised score and the optimiser's convergence code
+cat(sprintf("log posterior = %.1f;  convergence = %d (0 = success)\n",
+            est$log_posterior, est$convergence))
 ```
+
+::: {.caveat}
+**At scale.** Estimation cost grows as \( O(n^3 + n_t^3) \). For very large
+site counts, `n_sites` fits the hyperparameters on a random site subsample —
+they are shared, population-level quantities, so a representative subsample
+estimates the same values at a fraction of the cost (set a seed for
+reproducibility; time points are never subsampled). Prediction cost is
+dominated by the interval draws, which parallelise — see
+[*Running predictions in parallel*](parallel.html).
+:::
 
 The clearest check is to draw the **fitted** kernels (blue) on top of the
 **true** ones (navy, dashed). If the method worked, they overlap.
@@ -398,8 +489,10 @@ solve,
 \hat{f} = K S^\top \bigl(S K S^\top + \nu I\bigr)^{-1} g_{\text{obs}},
 \]
 
-(\( S \) selects the observed cells), so it is smooth and deterministic. The
-posterior **variance** splits into two parts:
+where \( S \) simply picks out the observed cells and
+\( \nu = \sigma^2 \eta \) is the observation-noise variance implied by the
+fitted nugget ratio — so the mean is smooth and deterministic. The posterior
+**variance** splits into two parts:
 
 \[
 \operatorname{Var}[f] \;=\;
@@ -413,21 +506,41 @@ If *no* weeks were missing, the posterior variance
 has an exact closed-form answer through the same Kronecker eigendecomposition
 used for fitting — no simulation needed. Missing weeks change that answer only
 *near the gaps*, so the draws are spent purely on the correction
-\( \Delta_{\text{gaps}} \): each perturbation draw (conditioned on the observed
-cells) is paired with an exact *complete-grid twin* built from the **same**
-random numbers, and the average of
-\( d_{\text{obs}}^2 - d_{\text{twin}}^2 \) estimates the correction. Sharing
-the randomness makes the difference nearly noise-free — a **control variate**.
+\( \Delta_{\text{gaps}} \). Each perturbation draw (Papandreou & Yuille 2010)
+draws \( u \sim \mathcal{N}(0, K) \) and \( e \sim \mathcal{N}(0, \nu I) \)
+and forms
+
+\[
+d_{\text{obs}} = u - K S^\top \bigl(S K S^\top + \nu I\bigr)^{-1}
+  \bigl(S u + S e\bigr),
+\]
+
+which has exactly the posterior covariance of the field. It is paired with an
+exact *complete-grid twin* \( d_{\text{twin}} \) built from the **same**
+\( u, e \), and the average of \( d_{\text{obs}}^2 - d_{\text{twin}}^2 \)
+estimates the correction. Sharing the randomness makes the difference nearly
+noise-free — a **control variate**.
 The latent-rate posterior is then combined with Negative-Binomial observation
-noise, via the **law of total variance** and a lognormal moment-match, to give
-a 95% **count** prediction interval:
+noise, via the **law of total variance**, to give the count mean and variance
 
 \[
 \mathbb{E}[y] = \mathbb{E}[\lambda], \qquad
 \operatorname{Var}[y] =
   \underbrace{\mathbb{E}\!\big[\lambda + \tfrac{\lambda^2}{r}\big]}_{\text{count noise}}
-  + \underbrace{\operatorname{Var}[\lambda]}_{\text{rate uncertainty}} .
+  + \underbrace{\operatorname{Var}[\lambda]}_{\text{rate uncertainty}} ,
 \]
+
+and the 95% interval comes from a **lognormal moment-match** to that mean and
+variance:
+
+\[
+s^2 = \log\!\left(1 + \frac{\operatorname{Var}[y]}{\mathbb{E}[y]^2}\right),
+\qquad
+m = \log \mathbb{E}[y] - \tfrac{s^2}{2},
+\]
+
+with the interval given by the 2.5% and 97.5% quantiles of
+\( \text{Lognormal}(m, s^2) \).
 :::
 
 ::: {.intuition}
@@ -460,7 +573,7 @@ The call returns one row per site-week with the posterior `rate` and, because
 `n_draws >= 1`, a 95% interval (`lower`, `upper`). The dispersion `r` used is
 attached as an attribute.
 
-```{r predict}
+```{r predict, warning = TRUE}
 # condition the GP on the observed cells and predict every site-week.
 # n_draws controls the paired draws that estimate the gap correction to the
 # variance -- the rest of the interval width is computed exactly, so modest
@@ -558,3 +671,8 @@ that make it quick also limit it:
 For a quick, honest summary of the spatial and temporal correlation structure —
 or a sensible starting point for a fuller model — it does the job in about a
 second.
+
+## References
+
+Papandreou, G. and Yuille, A. L. (2010). Gaussian sampling by local
+perturbations. *Advances in Neural Information Processing Systems 23*.

--- a/vignettes/walkthrough.Rmd
+++ b/vignettes/walkthrough.Rmd
@@ -67,6 +67,14 @@ f \sim \mathcal{N}\!\left(0,\ K_{\text{space}} \otimes K_{\text{time}}\right).
 - \( \otimes \) is the Kronecker product — the full space-time covariance is
   built from a small spatial kernel and a small temporal kernel
   ("separable").
+
+The Negative-Binomial assumption is lighter than it looks: it enters only the
+**prediction interval** (through the count-noise variance
+\( \lambda + \lambda^2/r \)). The hyperparameter estimates and the predicted
+rate are built from the Gaussian field on the \( \log(1+y) \) scale and do
+not depend on it. With no overdispersion the model reduces to Poisson —
+the limit \( r = \infty \), which the dispersion estimate returns
+automatically when the data show no excess variance.
 :::
 
 The kernels carry three hyperparameters — the knobs we want to estimate:


### PR DESCRIPTION
## What

A documentation overhaul collated from four parallel reviews — clarity, coverage (basic principles → full theory → package specifics), diagrams/plots/equations, and consistency/language/grammar — across the vignettes, README, roxygen help, and pkgdown config. ~50 findings applied.

## Structural

- **Roxygen markdown enabled** (`Roxygen: list(markdown = TRUE)`): help pages previously showed literal backticks, dead `[...]` links, and raw code fences; they now render as code, links, and `\preformatted{}` blocks.
- **New vignette — *Using weave with your own data***: the `data_process()` on-ramp from a raw data frame, the `t`-encoding contract (differences = real elapsed time, `period` in the same units), coordinate units (Euclidean; project first at scale), forecasting beyond the observed weeks via `NA` rows, and scaling guidance. Linked from the README and the walkthrough.
- **pkgdown reference index** organised into Core workflow / Kernels and distances / Building blocks; unexported helpers marked `@keywords internal`. Article order now gives a reading path: intro → walkthrough → data preparation → parallel.

## Correctness fixes

- **The GP intro's flagship "honest uncertainty" figure was structurally wrong**: the demo omitted the signal variance, so the 95% band missed the hidden truth over ~60% of the axis (band coverage 0.37, consistent across seeds). With σ² included — matching the vignette's own kernel equation — coverage is 1.0 and the band visibly balloons over the observation gap. Colours now follow the shared role palette (grey observations, navy truth, blue prediction).
- **DESCRIPTION** claimed prediction "by preconditioned conjugate gradient"; the solver is deliberately unpreconditioned. Also Title Case per CRAN convention.
- **`infer_kernel_params()`'s `coordinates` doc was stale**: it demanded an ordering that the code no longer needs (rows are matched by `id`) and omitted the required `id` column.
- The estimator is now honestly documented as a **MAP with weakly informative log-normal priors** (roxygen + walkthrough maths), not a pure maximum-likelihood fit.
- Kernel docs: equations added, `alpha`/`periodic_scale` described with direction of effect, titles no longer claim to "estimate".
- The **observation-distribution contract** is now explicit: Negative-Binomial enters only the prediction interval, `r = Inf` (Poisson) is a valid and auto-selected case, and counts must be non-negative integers.

## Content

- **Walkthrough**: ν and S defined at first use; the Papandreou & Yuille perturbation-draw construction and the lognormal moment-match equations stated (the theory is now auditable end to end); new missingness heatmap and Kronecker block-structure figures; single heading scheme; `t`-encoding and at-scale callouts; CG/optim warnings no longer suppressed in the fit and predict chunks.
- **Roxygen**: `quick_mvnorm*()` and `gp_marginal_loglik()` usable standalone (`@return` with vector ordering, upper-Cholesky requirement, runnable example); forecasting note in `gp_predict()`; ASCII-safe maths in Rd for the PDF manual.
- **Consistency pass**: typos (incl. "sapace"), British English, terminology (site-week, length-scale), Oxford commas, spaced dashes, `fig.alt` text on all vignette figures.

## Verification

- `devtools::test()`: 99 pass, 0 fail (two error messages were reworded)
- All four vignettes knit; every changed figure inspected as rendered output
- `README.md` regenerated from `README.Rmd`; `pkgdown::check_pkgdown()` clean
- `R CMD check`: 0 errors, 0 warnings (one environmental clock NOTE)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
