### PR TITLE
Restructure the walkthrough and add a Kronecker-trick vignette

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -93,6 +93,8 @@ prediction interval.
 - [Using weave with your own data](https://mrc-ide.github.io/weave/articles/data-preparation.html)
   — preparing raw data with `data_process()`, encoding time correctly, and
   predicting beyond the observed weeks.
+- [The Kronecker trick](https://mrc-ide.github.io/weave/articles/kronecker.html)
+  — why fitting and prediction stay fast and exact at scale.
 - [Running predictions in parallel](https://mrc-ide.github.io/weave/articles/parallel.html)
   — one line of setup to spread the prediction draws across CPU cores;
   identical results.

--- a/README.md
+++ b/README.md
@@ -88,6 +88,9 @@ pred <- gp_predict(obs_data, coordinates, hyperparameters = est,
   data](https://mrc-ide.github.io/weave/articles/data-preparation.html)
   — preparing raw data with `data_process()`, encoding time correctly,
   and predicting beyond the observed weeks.
+- [The Kronecker
+  trick](https://mrc-ide.github.io/weave/articles/kronecker.html) — why
+  fitting and prediction stay fast and exact at scale.
 - [Running predictions in
   parallel](https://mrc-ide.github.io/weave/articles/parallel.html) —
   one line of setup to spread the prediction draws across CPU cores;

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -19,6 +19,7 @@ articles:
   - gaussian-processes
   - walkthrough
   - data-preparation
+  - kronecker
   - parallel
 
 reference:

--- a/vignettes/gaussian-processes.Rmd
+++ b/vignettes/gaussian-processes.Rmd
@@ -251,8 +251,8 @@ facilities are expected to behave alike. Space and time are then combined into
 a single space-time covariance with a *separable* structure,
 \( K_{\text{space}} \otimes K_{\text{time}} \) — the *Kronecker product*, a
 recipe that builds the one enormous space-time matrix from the two small
-ones — which keeps the model fast, a point the
-[walkthrough](walkthrough.html) returns to. Three numbers control
+ones — which keeps the model fast (explained in
+[*The Kronecker trick*](kronecker.html)). Three numbers control
 all of this: the spatial `length_scale`, the `periodic_scale`, and the
 `long_term_scale`. Estimating them from data is the subject of that article.
 

--- a/vignettes/kronecker.Rmd
+++ b/vignettes/kronecker.Rmd
@@ -209,8 +209,9 @@ conjugate-gradient iteration cheap even at large \( N \).
 
 ::: {.intuition}
 A separable kernel means space and time can be handled separately. So
-instead of one enormous matrix we juggle two small ones — one for space, one
-for time — which is dramatically cheaper and gives the *exact* same answer.
+instead of one enormous matrix we work with two small ones — one for space,
+one for time — which is dramatically cheaper and gives the *exact* same
+answer.
 This is why the estimate takes a second rather than hours.
 :::
 

--- a/vignettes/kronecker.Rmd
+++ b/vignettes/kronecker.Rmd
@@ -1,0 +1,150 @@
+---
+title: "The Kronecker trick: why weave is fast"
+output:
+  rmarkdown::html_vignette:
+    css: weave.css
+vignette: >
+  %\VignetteIndexEntry{The Kronecker trick: why weave is fast}
+  %\VignetteEncoding{UTF-8}
+  %\VignetteEngine{knitr::rmarkdown}
+editor_options:
+  markdown:
+    wrap: 72
+---
+
+```{r, include = FALSE}
+library(ggplot2)
+source("_common.R")
+```
+
+```{r setup, include = FALSE}
+library(weave)
+```
+
+A weave model has one cell per site and week: \( N = n \cdot n_t \) cells in
+total. The Gaussian-process covariance over those cells is an
+\( N \times N \) matrix — at 1000 sites and five years of weeks that is
+around 67 *billion* entries. weave never forms it, never inverts it, and
+never approximates it. Everything in
+[the walkthrough](walkthrough.html) — fitting the hyperparameters and
+computing the exact part of the prediction interval — stays exact because
+the covariance is **separable**, and separable covariances can be handled
+through their small factors alone. This article explains the two identities
+that make that work.
+
+## One small matrix per dimension
+
+The model assumes the covariance factorises into a spatial part and a
+temporal part:
+
+\[
+K \;=\; K_{\text{space}} \otimes K_{\text{time}},
+\]
+
+where \( K_{\text{space}} \) is \( n \times n \), \( K_{\text{time}} \) is
+\( n_t \times n_t \), and \( \otimes \) is the **Kronecker product** — a
+recipe that builds the one enormous matrix from the two small ones: the
+covariance between cell \( (s, t) \) and cell \( (s', t') \) is simply
+\( K_{\text{space}}[s, s'] \times K_{\text{time}}[t, t'] \).
+
+The structure is easiest to see. Below is the full space-time covariance for
+a toy problem of 3 sites × 8 weeks: a 24 × 24 matrix, but built entirely from
+a 3 × 3 spatial kernel and an 8 × 8 temporal one. Each 8 × 8 block is the
+temporal kernel scaled by one entry of the spatial kernel — the whole matrix
+never needs to exist:
+
+```{r kron-schematic, echo = FALSE, fig.height = 4.4, fig.alt = "Heatmap of a 24-by-24 Kronecker-product covariance matrix showing a 3-by-3 grid of 8-by-8 blocks; each block is the temporal kernel scaled by one spatial kernel entry"}
+n_toy <- 3; nt_toy <- 8
+coords_toy <- data.frame(id = 1:n_toy, lon = c(0, 1, 4), lat = c(0, 1, 0))
+Ks_toy <- space_kernel(coords_toy, length_scale = 2)
+Kt_toy <- time_kernel(1:nt_toy, periodic_scale = 1, long_term_scale = 50,
+                      period = 8)
+K_toy  <- kronecker(Ks_toy, Kt_toy)
+
+kron_df <- expand.grid(row = 1:(n_toy * nt_toy), col = 1:(n_toy * nt_toy))
+kron_df$value <- as.vector(K_toy)
+
+ggplot(kron_df, aes(col, row, fill = value)) +
+  geom_tile() +
+  geom_hline(yintercept = c(8.5, 16.5), colour = "white", linewidth = 0.8) +
+  geom_vline(xintercept = c(8.5, 16.5), colour = "white", linewidth = 0.8) +
+  scale_y_reverse() +
+  scale_fill_gradient(low = "#f7f1e8", high = weave_cols[["prediction"]],
+                      name = "covariance") +
+  coord_fixed() +
+  labs(x = NULL, y = NULL,
+       title = "The full covariance for 3 sites × 8 weeks",
+       subtitle = "each 8×8 block = temporal kernel × one spatial kernel entry") +
+  theme_weave() +
+  theme(axis.text = element_blank(), panel.grid.major = element_blank())
+```
+
+Statistically, separability says the *shape* of the temporal correlation is
+the same at every site (and vice versa) — a modelling assumption, and the
+price of everything below.
+
+## Identity 1: determinants and quadratic forms (used in fitting)
+
+Fitting the hyperparameters requires the log marginal likelihood of the
+plug-in field \( g \), which needs \( \log|K| \) and
+\( g^\top K^{-1} g \) — normally hopeless at size \( N \). Because the
+covariance is a Kronecker product plus a diagonal nugget, eigendecomposing
+the *small* factors
+\( R_{\text{space}} = U_s \Lambda_s U_s^\top \) (size \( n \)) and
+\( R_{\text{time}} = U_t \Lambda_t U_t^\top \) (size \( n_t \)) is enough:
+
+\[
+\log\bigl|R_{\text{space}} \otimes R_{\text{time}} + \eta I\bigr|
+  = \sum_{i,j} \log(a_i b_j + \eta), \qquad
+g^\top \bigl(R_{\text{space}} \otimes R_{\text{time}} + \eta I\bigr)^{-1} g
+  = \sum_{i,j} \frac{G_{ij}^2}{a_i b_j + \eta},
+\]
+
+with \( a_i, b_j \) the eigenvalues, \( G = U_s^\top F U_t \), and \( F \)
+the field reshaped to \( n \times n_t \). This works because the Kronecker
+product's eigenvectors are themselves a Kronecker product
+(\( U_s \otimes U_t \)), and a nugget \( \eta I \) only shifts the
+eigenvalues. The cost is \( O(n^3 + n_t^3) \) instead of
+\( O\big((n\,n_t)^3\big) \) — for the 1000-site example above, that is the
+difference between a second and centuries.
+
+The same eigendecomposition gives the *exact* complete-grid posterior
+variance used by the prediction interval — the
+\( V_{\text{complete}} \) term in the walkthrough — again without ever
+forming \( K \).
+
+## Identity 2: multiplying by K without forming it (used in prediction)
+
+Predicting needs solves of the form
+\( (S K S^\top + \nu I)^{-1} b \) (one for the posterior mean, one per
+perturbation draw). weave uses the conjugate-gradient method, which never
+needs \( K \) itself — only the ability to compute \( K v \) for a given
+vector \( v \). For a Kronecker product that is a reshape away:
+
+\[
+\bigl(K_{\text{space}} \otimes K_{\text{time}}\bigr)\, v
+  \;=\; \operatorname{vec}\!\bigl(K_{\text{time}}\, V\, K_{\text{space}}\bigr),
+\]
+
+where \( V \) is \( v \) reshaped to an \( n_t \times n \) matrix (weave's
+vector layout puts time fastest, and the kernels are symmetric). Each
+product costs two small matrix multiplications instead of one enormous one —
+this is the package's `kron_mv()` building block, and it is what makes each
+conjugate-gradient iteration cheap even at large \( N \).
+
+## What this buys
+
+::: {.intuition}
+A separable kernel means space and time can be handled separately. So
+instead of one enormous matrix we juggle two small ones — one for space, one
+for time — which is dramatically cheaper and gives the *exact* same answer.
+This is why the estimate takes a second rather than hours.
+:::
+
+Everything downstream inherits the speed: hyperparameter fitting evaluates
+the exact likelihood thousands of times inside the optimiser
+(identity 1), the exact part of the prediction interval is closed-form
+(identity 1 again), and the gap-correction draws each cost a handful of
+cheap matrix-vector products (identity 2). None of it is an approximation —
+the only approximations in weave are the statistical ones listed at the end
+of [the walkthrough](walkthrough.html).

--- a/vignettes/kronecker.Rmd
+++ b/vignettes/kronecker.Rmd
@@ -47,37 +47,110 @@ recipe that builds the one enormous matrix from the two small ones: the
 covariance between cell \( (s, t) \) and cell \( (s', t') \) is simply
 \( K_{\text{space}}[s, s'] \times K_{\text{time}}[t, t'] \).
 
-The structure is easiest to see. Below is the full space-time covariance for
-a toy problem of 3 sites × 8 weeks: a 24 × 24 matrix, but built entirely from
-a 3 × 3 spatial kernel and an 8 × 8 temporal one. Each 8 × 8 block is the
-temporal kernel scaled by one entry of the spatial kernel — the whole matrix
-never needs to exist:
+### Seeing the structure
 
-```{r kron-schematic, echo = FALSE, fig.height = 4.4, fig.alt = "Heatmap of a 24-by-24 Kronecker-product covariance matrix showing a 3-by-3 grid of 8-by-8 blocks; each block is the temporal kernel scaled by one spatial kernel entry"}
+A toy problem makes the recipe concrete: 3 sites × 8 weeks, so 24 cells and a
+24 × 24 covariance. We build it from the two small pieces.
+
+**The spatial kernel** holds one correlation per *pair of sites*. In the toy,
+sites 1 and 2 sit close together and site 3 sits far away — and the matrix
+says exactly that:
+
+```{r kron-space, echo = FALSE, fig.height = 2.8, fig.alt = "A 3-by-3 spatial correlation matrix shown as a heatmap with the numeric value printed in each cell; sites 1 and 2 are strongly correlated (0.78), site 3 is weakly correlated with both"}
 n_toy <- 3; nt_toy <- 8
 coords_toy <- data.frame(id = 1:n_toy, lon = c(0, 1, 4), lat = c(0, 1, 0))
 Ks_toy <- space_kernel(coords_toy, length_scale = 2)
-Kt_toy <- time_kernel(1:nt_toy, periodic_scale = 1, long_term_scale = 50,
-                      period = 8)
+Kt_toy <- time_kernel(1:nt_toy, periodic_scale = 1, long_term_scale = 4,
+                      period = 52)
 K_toy  <- kronecker(Ks_toy, Kt_toy)
 
-kron_df <- expand.grid(row = 1:(n_toy * nt_toy), col = 1:(n_toy * nt_toy))
-kron_df$value <- as.vector(K_toy)
+tile_df <- function(M) {
+  d <- expand.grid(row = seq_len(nrow(M)), col = seq_len(ncol(M)))
+  d$value <- M[cbind(d$row, d$col)]
+  d
+}
 
-ggplot(kron_df, aes(col, row, fill = value)) +
-  geom_tile() +
-  geom_hline(yintercept = c(8.5, 16.5), colour = "white", linewidth = 0.8) +
-  geom_vline(xintercept = c(8.5, 16.5), colour = "white", linewidth = 0.8) +
-  scale_y_reverse() +
+ggplot(tile_df(Ks_toy), aes(col, row, fill = value)) +
+  geom_tile(colour = "white", linewidth = 1) +
+  geom_text(aes(label = sprintf("%.2f", value),
+                colour = value > 0.5), size = 4.2, fontface = "bold") +
+  scale_colour_manual(values = c(`TRUE` = "white", `FALSE` = weave_navy),
+                      guide = "none") +
+  scale_y_reverse(breaks = 1:3, labels = paste("site", 1:3)) +
+  scale_x_continuous(breaks = 1:3, labels = paste("site", 1:3),
+                     position = "top") +
   scale_fill_gradient(low = "#f7f1e8", high = weave_cols[["prediction"]],
-                      name = "covariance") +
+                      limits = c(0, 1), oob = scales::squish,
+                      guide = "none") +
   coord_fixed() +
-  labs(x = NULL, y = NULL,
-       title = "The full covariance for 3 sites × 8 weeks",
-       subtitle = "each 8×8 block = temporal kernel × one spatial kernel entry") +
+  labs(x = NULL, y = NULL, title = "Spatial kernel (3 × 3)",
+       subtitle = "one correlation per pair of sites") +
   theme_weave() +
-  theme(axis.text = element_blank(), panel.grid.major = element_blank())
+  theme(panel.grid.major = element_blank(),
+        axis.line = element_blank(), axis.ticks = element_blank())
 ```
+
+**The temporal kernel** holds one correlation per *pair of weeks*. Its banded
+shape says that nearby weeks look alike and the resemblance fades with lag:
+
+```{r kron-time, echo = FALSE, fig.height = 3.2, fig.alt = "An 8-by-8 temporal correlation matrix shown as a heatmap with a banded structure: strong correlation near the diagonal fading with temporal lag"}
+ggplot(tile_df(Kt_toy), aes(col, row, fill = value)) +
+  geom_tile(colour = "white", linewidth = 0.4) +
+  geom_text(aes(label = sprintf("%.2f", value),
+                colour = value > 0.5), size = 2.6) +
+  scale_colour_manual(values = c(`TRUE` = "white", `FALSE` = weave_navy),
+                      guide = "none") +
+  scale_y_reverse(breaks = 1:8, labels = paste("week", 1:8)) +
+  scale_x_continuous(breaks = 1:8, position = "top") +
+  scale_fill_gradient(low = "#f7f1e8", high = weave_cols[["prediction"]],
+                      limits = c(0, 1), oob = scales::squish,
+                      guide = "none") +
+  coord_fixed() +
+  labs(x = NULL, y = NULL, title = "Temporal kernel (8 × 8)",
+       subtitle = "one correlation per pair of weeks, fading with lag") +
+  theme_weave() +
+  theme(panel.grid.major = element_blank(),
+        axis.line = element_blank(), axis.ticks = element_blank())
+```
+
+**The Kronecker product assembles the full covariance from those two.** Lay
+out a 3 × 3 grid of blocks — one block per pair of sites — and make each
+block a copy of the whole 8 × 8 temporal kernel, dimmed by that site pair's
+spatial correlation. Sites 1 and 2 are highly correlated (0.78), so their
+off-diagonal blocks are nearly as strong as the diagonal; site 3 is far from
+site 1 (0.14), so their block — outlined in navy below — is the same temporal
+pattern, just faint:
+
+```{r kron-product, echo = FALSE, fig.height = 4.8, fig.alt = "The full 24-by-24 space-time covariance as a heatmap of 9 blocks in a 3-by-3 grid; each block repeats the temporal kernel scaled by one spatial correlation, and the faint block linking site 1 and site 3 is outlined in navy"}
+ggplot(tile_df(K_toy), aes(col, row, fill = value)) +
+  geom_tile() +
+  geom_hline(yintercept = c(8.5, 16.5), colour = "white", linewidth = 1) +
+  geom_vline(xintercept = c(8.5, 16.5), colour = "white", linewidth = 1) +
+  annotate("rect", xmin = 16.5, xmax = 24.5, ymin = 0.5, ymax = 8.5,
+           fill = NA, colour = weave_navy, linewidth = 1) +
+  annotate("text", x = 20.5, y = 4.5, label = "0.14 x the\ntemporal kernel",
+           colour = weave_navy, size = 3.4, fontface = "bold", lineheight = 1) +
+  scale_y_reverse(breaks = c(4.5, 12.5, 20.5), labels = paste("site", 1:3)) +
+  scale_x_continuous(breaks = c(4.5, 12.5, 20.5), labels = paste("site", 1:3),
+                     position = "top") +
+  scale_fill_gradient(low = "#f7f1e8", high = weave_cols[["prediction"]],
+                      limits = c(0, 1), oob = scales::squish,
+                      name = "correlation") +
+  coord_fixed(clip = "off") +
+  labs(x = NULL, y = NULL,
+       title = "Space-time covariance (24 × 24)",
+       subtitle = "each block = the temporal kernel × one spatial entry") +
+  theme_weave() +
+  theme(panel.grid.major = element_blank(),
+        axis.line = element_blank(), axis.ticks = element_blank())
+```
+
+Read any single entry the same way: the covariance between cell
+\( (s, t) \) and cell \( (s', t') \) is
+\( K_{\text{space}}[s, s'] \times K_{\text{time}}[t, t'] \) — always a
+product of one number from each small matrix. That is all \( \otimes \)
+means, and it is why the 24 × 24 matrix (or the 67-billion-entry one) never
+needs to exist: the two small matrices carry every entry implicitly.
 
 Statistically, separability says the *shape* of the temporal correlation is
 the same at every site (and vice versa) — a modelling assumption, and the

--- a/vignettes/walkthrough.Rmd
+++ b/vignettes/walkthrough.Rmd
@@ -4,7 +4,7 @@ output:
   rmarkdown::html_vignette:
     css: weave.css
     toc: true
-    toc_depth: 2
+    toc_depth: 3
 vignette: >
   %\VignetteIndexEntry{The weave walkthrough: estimating kernels and predicting rates}
   %\VignetteEncoding{UTF-8}
@@ -28,14 +28,16 @@ This article is a complete walkthrough of how `weave` turns noisy, gappy count
 data into a smooth estimate of an underlying rate. If the ideas of a Gaussian
 process and a kernel are new, the companion
 [*gentle introduction*](gaussian-processes.html) builds them up first; here we
-apply them. The walkthrough has two halves:
+apply them. The walkthrough has three parts:
 
-1. **Estimate the kernel hyperparameters** — the handful of numbers that say
-   how quickly counts become uncorrelated as we move apart in space and in
-   time.
-2. **Use them to predict** — denoise the observed counts, *fill in the missing
-   weeks*, and place an honest **prediction interval** around every estimate
-   with `gp_predict()`.
+1. **The model** — what we assume generates the counts, the kernels that
+   encode smoothness, and the simulated data we will use throughout.
+2. **Fitting the kernel hyperparameters** — how the handful of numbers that
+   say how quickly counts become uncorrelated in space and time are
+   estimated, including the EM-style handling of missing weeks.
+3. **From fitted kernels to predictions** — the best-guess rate at every
+   site and week, and an honest **prediction interval** around it, with
+   `gp_predict()`.
 
 We use a small simulated example with a *known* answer (including known missing
 weeks), so we can watch the method recover the truth. At each stage we give the
@@ -48,6 +50,8 @@ at the end.
 :::
 
 ## 1. The model
+
+### The observation model: counts by site and week
 
 ::: {.maths}
 We observe a count `y` at every site `s` (a health facility) and time `t`
@@ -66,7 +70,8 @@ f \sim \mathcal{N}\!\left(0,\ K_{\text{space}} \otimes K_{\text{time}}\right).
   how correlated two cells are as a function of their separation.
 - \( \otimes \) is the Kronecker product — the full space-time covariance is
   built from a small spatial kernel and a small temporal kernel
-  ("separable").
+  ("separable"). This structure is also why everything below is fast: see
+  [*The Kronecker trick*](kronecker.html).
 
 The Negative-Binomial assumption is lighter than it looks: it enters only the
 **prediction interval** (through the count-noise variance
@@ -77,21 +82,32 @@ the limit \( r = \infty \), which the dispersion estimate returns
 automatically when the data show no excess variance.
 :::
 
-The kernels carry three hyperparameters — the knobs we want to estimate:
+::: {.intuition}
+Each facility has a smooth underlying rate of cases. Nearby facilities, and
+nearby weeks, tend to look similar; far-apart ones drift. The kernels control
+*how quickly* that resemblance fades with distance in space and in time. Our
+whole task is to read their parameters off the data.
+:::
+
+### The kernels and their hyperparameters
+
+The spatial kernel is an RBF (squared-exponential) on the distance between
+sites; the temporal kernel is a periodic kernel (the seasonal cycle)
+multiplied by a slowly-decaying RBF (the long-run drift). Between them they
+carry three hyperparameters — the knobs we want to estimate:
 
 - `length_scale` — how far apart two sites must be before they stop looking
   alike (spatial RBF kernel);
 - `periodic_scale` — how sharply the yearly season rises and falls;
 - `long_term_scale` — how slowly the year-on-year level drifts.
 
-::: {.intuition}
-Each facility has a smooth underlying rate of cases. Nearby facilities, and
-nearby weeks, tend to look similar; far-apart ones drift. The three knobs
-control *how quickly* that resemblance fades with distance in space and in
-time. Our whole task is to read those three numbers off the data.
-:::
+A fourth, the **nugget ratio**, is estimated alongside them: the share of the
+variance that is observation noise rather than smooth signal. Its role is
+explained in part 2. (The [*gentle introduction*](gaussian-processes.html)
+shows what each kernel looks like and how its parameter changes the curves it
+generates.)
 
-### The worked example
+### The worked example: simulated data with missing weeks
 
 We simulate data with *chosen* true knobs, so we can check the answer. The
 small helpers that draw the counts and punch clustered gaps into them
@@ -222,7 +238,14 @@ ggplot() +
   theme_weave()
 ```
 
-## 2. A quick "plug-in" latent field
+## 2. Fitting the kernel hyperparameters
+
+Estimation happens in two moves: build a cheap stand-in for the latent field
+we cannot see, then search for the kernel parameters under which that
+stand-in looks most plausible. Missing weeks get a dedicated correction — an
+EM-style refinement — described at the end of this part.
+
+### A quick plug-in latent field
 
 ::: {.maths}
 We cannot see the latent field \( f \) directly, so we build a cheap stand-in
@@ -243,8 +266,6 @@ matches \( f \). Subtracting each site's average removes the baseline
 every site on the same footing, so a single set of knobs applies to all of
 them. It is noisy — but it is instant.
 :::
-
-### The worked example
 
 ```{r plugin}
 # the plug-in field: per-site centred & scaled log(1 + y), as one long vector
@@ -277,7 +298,7 @@ ggplot(plot_df, aes(t, value, colour = type)) +
   theme_weave()
 ```
 
-## 3. Score the knobs with the marginal likelihood
+### Scoring candidate hyperparameters: the marginal likelihood
 
 ::: {.maths}
 For a candidate set of hyperparameters \( \theta \) the kernels give a
@@ -317,77 +338,21 @@ kernel would have to explain the noisy plug-in field with smoothness alone,
 badly distorting the length-scales.
 :::
 
-## 4. Why it is fast: the Kronecker trick
+Evaluating \( \log|K| \) and \( g^\top K^{-1} g \) sounds hopeless — here
+\( K \) is `r n * nt` square, and the optimiser scores thousands of
+candidates. Because the kernel is separable, both quantities come exactly
+from eigendecompositions of the two *small* kernels, at
+\( O(n^3 + n_t^3) \) cost instead of \( O\big((n\,n_t)^3\big) \). How that
+works is its own short story: see
+[*The Kronecker trick*](kronecker.html).
 
-::: {.maths}
-The full covariance is \( (n \cdot n_t) \times (n \cdot n_t) \) — here
-`r n * nt` square. We never form it. Because it is a Kronecker product,
-eigendecomposing the *small* factors
-\( R_{\text{space}} = U_s \Lambda_s U_s^\top \) (size \( n \)) and
-\( R_{\text{time}} = U_t \Lambda_t U_t^\top \) (size \( n_t \)) is enough:
+### Handling the gaps: EM refinement
 
-\[
-\log\bigl|R_{\text{space}} \otimes R_{\text{time}} + \eta I\bigr|
-  = \sum_{i,j} \log(a_i b_j + \eta), \qquad
-g^\top \bigl(R_{\text{space}} \otimes R_{\text{time}} + \eta I\bigr)^{-1} g
-  = \sum_{i,j} \frac{G_{ij}^2}{a_i b_j + \eta},
-\]
-
-with \( a_i, b_j \) the eigenvalues, \( G = U_s^\top F U_t \), and \( F \) the
-field reshaped to \( n \times n_t \). The cost is \( O(n^3 + n_t^3) \) instead
-of \( O\big((n\,n_t)^3\big) \).
-:::
-
-::: {.intuition}
-A separable kernel means space and time can be handled separately. So instead
-of one enormous matrix we juggle two small ones — one for space, one for time
-— which is dramatically cheaper and gives the *exact* same answer. This is why
-the estimate takes a second rather than hours.
-:::
-
-The structure is easiest to see. Below is the full space-time covariance for
-a toy problem of 3 sites × 8 weeks: a 24 × 24 matrix, but built entirely from
-a 3 × 3 spatial kernel and an 8 × 8 temporal one. Each 8 × 8 block is the
-temporal kernel scaled by one entry of the spatial kernel — the whole matrix
-never needs to exist:
-
-```{r kron-schematic, echo = FALSE, fig.height = 4.4, fig.alt = "Heatmap of a 24-by-24 Kronecker-product covariance matrix showing a 3-by-3 grid of 8-by-8 blocks; each block is the temporal kernel scaled by one spatial kernel entry"}
-n_toy <- 3; nt_toy <- 8
-coords_toy <- data.frame(id = 1:n_toy, lon = c(0, 1, 4), lat = c(0, 1, 0))
-Ks_toy <- space_kernel(coords_toy, length_scale = 2)
-Kt_toy <- time_kernel(1:nt_toy, periodic_scale = 1, long_term_scale = 50,
-                      period = 8)
-K_toy  <- kronecker(Ks_toy, Kt_toy)
-
-kron_df <- expand.grid(row = 1:(n_toy * nt_toy), col = 1:(n_toy * nt_toy))
-kron_df$value <- as.vector(K_toy)
-
-ggplot(kron_df, aes(col, row, fill = value)) +
-  geom_tile() +
-  geom_hline(yintercept = c(8.5, 16.5), colour = "white", linewidth = 0.8) +
-  geom_vline(xintercept = c(8.5, 16.5), colour = "white", linewidth = 0.8) +
-  scale_y_reverse() +
-  scale_fill_gradient(low = "#f7f1e8", high = weave_cols[["prediction"]],
-                      name = "covariance") +
-  coord_fixed() +
-  labs(x = NULL, y = NULL,
-       title = "The full covariance for 3 sites × 8 weeks",
-       subtitle = "each 8×8 block = temporal kernel × one spatial kernel entry") +
-  theme_weave() +
-  theme(axis.text = element_blank(), panel.grid.major = element_blank())
-```
-
-## 5. Fit, and check against the truth
-
-`infer_kernel_params()` does all of the above: build the plug-in field, then
-maximise the marginal likelihood over the three length-scales plus the nugget
-ratio.
-
-We switch on `refine = TRUE`. Filling the missing weeks with a flat per-site
-mean makes the field look as if the signal dies in every gap, which biases the
-length-scales downward (the seasonal and long-run scales suffer most). With
-`refine`, the fit instead fills each gap with the GP's *own* conditional mean
-and refits a handful of times, which removes that gap-induced bias.
+Filling the missing weeks with a flat per-site mean makes the field look as
+if the signal dies in every gap, which biases the length-scales downward (the
+seasonal and long-run scales suffer most). Setting `refine = TRUE` removes
+that bias: the fit fills each gap with the GP's *own* conditional mean and
+refits a handful of times.
 
 ::: {.intuition}
 This loop is exactly the **EM algorithm** for a fit with missing data, alternating
@@ -405,9 +370,16 @@ Each pass feeds the next, and two or three are enough to converge — landing on
 essentially the estimate we would have got with *no* gaps at all. Crucially, the
 expensive conditional-mean solve runs only once per pass, never inside the
 optimiser, so the whole correction stays cheap. (It removes the bias the *gaps*
-cause; the residual plug-in attenuation below — from conditioning on a noisy
-field rather than integrating it out — is a separate matter it does not fix.)
+cause; the residual plug-in attenuation listed in the caveats — from
+conditioning on a noisy field rather than integrating it out — is a separate
+matter it does not fix.)
 :::
+
+### The worked example: fit and check
+
+`infer_kernel_params()` does all of the above: build the plug-in field, then
+maximise the score over the three length-scales plus the nugget ratio, with
+`refine = TRUE` switched on because our data has gaps.
 
 ```{r infer, warning = TRUE}
 # maximise the GP marginal likelihood to recover the three length-scales
@@ -482,16 +454,19 @@ ggplot(rbind(fit$time, true$time),
   theme_weave()
 ```
 
-## 6. Predict: smoothing, gap-filling, and prediction intervals
+## 3. From fitted kernels to predictions
 
 With the kernels estimated, we put them to work: clean up the noise, fill in
-the missing weeks, and say how *uncertain* each estimate is. A single function,
-`gp_predict()`, does all three.
+the missing weeks, and say how *uncertain* each estimate is. A single
+function, `gp_predict()`, does both of the pieces below in one call.
+
+### The best guess: the posterior mean
 
 ::: {.maths}
 `gp_predict()` conditions a separable Gaussian process on the **observed cells
 only**. The posterior **mean** of the latent field comes from one matrix-free
-solve,
+conjugate-gradient solve (cheap because multiplying by \( K \) never forms it
+— see [*The Kronecker trick*](kronecker.html)),
 
 \[
 \hat{f} = K S^\top \bigl(S K S^\top + \nu I\bigr)^{-1} g_{\text{obs}},
@@ -499,8 +474,21 @@ solve,
 
 where \( S \) simply picks out the observed cells and
 \( \nu = \sigma^2 \eta \) is the observation-noise variance implied by the
-fitted nugget ratio — so the mean is smooth and deterministic. The posterior
-**variance** splits into two parts:
+fitted nugget ratio. The mean is smooth and deterministic — it does not
+depend on how many draws are used for the interval.
+:::
+
+::: {.intuition}
+Because it conditions on the observed set, missing weeks are filled by genuine
+GP interpolation — the model's best guess given every week it *did* see,
+weighted by the fitted correlations — unlike a smoother that quietly
+mean-imputes the gaps.
+:::
+
+### The interval: exact variance plus a "gaps" correction
+
+::: {.maths}
+The posterior **variance** splits into two parts:
 
 \[
 \operatorname{Var}[f] \;=\;
@@ -552,10 +540,6 @@ with the interval given by the 2.5% and 97.5% quantiles of
 :::
 
 ::: {.intuition}
-Because it conditions on the observed set, missing weeks are filled by genuine
-GP interpolation, and their interval can *widen over gaps* — unlike a smoother
-that quietly mean-imputes the gaps.
-
 The variance trick is worth restating in plain words. Most of the uncertainty
 is known **exactly** — the only thing simulation must measure is *how much the
 gaps inflate it*. So instead of asking the draws to estimate the whole
@@ -575,7 +559,7 @@ estimate from the likelihood, so it is recovered by method of moments from the
 observed counts.
 :::
 
-### The worked example
+### The worked example: predict, then check the coverage
 
 The call returns one row per site-week with the posterior `rate` and, because
 `n_draws >= 1`, a 95% interval (`lower`, `upper`). The dispersion `r` used is
@@ -625,8 +609,6 @@ short companion article
 [*Running predictions in parallel*](parallel.html) — one line of setup, and
 the numbers are guaranteed not to change.
 
-### Did we fill the gaps well?
-
 The honest test is the **held-out** weeks: does the 95% interval contain the
 counts the model never saw? It should, about 95% of the time.
 
@@ -649,7 +631,7 @@ can drift a little here because this is a small example and the quick method
 does not propagate every source of uncertainty (see below).
 :::
 
-## 7. Caveats and approximations
+## Caveats and approximations
 
 ::: {.caveat}
 This is a fast, deterministic estimate — not a full posterior. The shortcuts

--- a/vignettes/walkthrough.Rmd
+++ b/vignettes/walkthrough.Rmd
@@ -32,9 +32,9 @@ apply them. The walkthrough has three parts:
 
 1. **The model** — what we assume generates the counts, the kernels that
    encode smoothness, and the simulated data we will use throughout.
-2. **Fitting the kernel hyperparameters** — how the handful of numbers that
-   say how quickly counts become uncorrelated in space and time are
-   estimated, including the EM-style handling of missing weeks.
+2. **Fitting the kernel hyperparameters** — how the parameters that control
+   how quickly counts become uncorrelated in space and time are estimated,
+   including the EM-style handling of missing weeks.
 3. **From fitted kernels to predictions** — the best-guess rate at every
    site and week, and an honest **prediction interval** around it, with
    `gp_predict()`.
@@ -94,7 +94,7 @@ whole task is to read their parameters off the data.
 The spatial kernel is an RBF (squared-exponential) on the distance between
 sites; the temporal kernel is a periodic kernel (the seasonal cycle)
 multiplied by a slowly-decaying RBF (the long-run drift). Between them they
-carry three hyperparameters — the knobs we want to estimate:
+carry three hyperparameters — the quantities we want to estimate:
 
 - `length_scale` — how far apart two sites must be before they stop looking
   alike (spatial RBF kernel);
@@ -109,14 +109,14 @@ generates.)
 
 ### The worked example: simulated data with missing weeks
 
-We simulate data with *chosen* true knobs, so we can check the answer. The
-small helpers that draw the counts and punch clustered gaps into them
-(`simulate_data()`, `observed_data()`) are example scaffolding, not part of the
-package, so they are hidden here.
+We simulate data with *chosen* true hyperparameters, so we can check the
+answer. The small helpers that draw the counts and remove clustered runs of
+weeks (`simulate_data()`, `observed_data()`) are example scaffolding, not part
+of the package, so they are hidden here.
 
 ```{r sim-helpers, echo = FALSE}
 # Example-only helpers (NOT part of weave). They draw a Negative-Binomial GP and
-# then knock out clustered runs of weeks, mimicking real reporting dropouts.
+# then remove clustered runs of weeks, mimicking real reporting dropouts.
 simulate_data <- function(n, nt, coordinates, space_k, time_k, r) {
   f      <- quick_mvnorm(space_k, time_k)        # latent field, time fastest
   lambda <- exp(rep(coordinates$mu, each = nt) + f)
@@ -148,7 +148,7 @@ n      <- 20          # sites (health facilities)
 nt     <- 52 * 3      # weeks (3 years)
 period <- 52          # weeks per seasonal cycle
 
-# the "true" kernel knobs we will try to recover
+# the true kernel hyperparameters we will try to recover
 true_length_scale    <- 2     # spatial smoothness
 true_periodic_scale  <- 1.1   # how sharp the season is
 true_long_term_scale <- 150   # long-run drift
@@ -263,8 +263,8 @@ divide by its standard deviation.
 The logarithm turns the multiplicative "rate" scale into an additive one that
 matches \( f \). Subtracting each site's average removes the baseline
 \( \mu_s \) (which we do not care about here), and dividing by the spread puts
-every site on the same footing, so a single set of knobs applies to all of
-them. It is noisy — but it is instant.
+every site on the same footing, so a single set of hyperparameters applies to
+all of them. It is noisy — but it is instant.
 :::
 
 ```{r plugin}
@@ -327,10 +327,11 @@ identified parameters (notably `long_term_scale`) off the boundary.
 :::
 
 ::: {.intuition}
-For any guess at the knobs we can ask: *how plausible is the plug-in field if
-the world really had this much smoothness?* The first term (\( \log|K| \))
-penalises over-flexible kernels (an "Occam" penalty); the second rewards
-kernels that explain the field well. We turn the dial until the score is best.
+For any candidate hyperparameters we can ask: *how plausible is the plug-in
+field if the world really had this much smoothness?* The first term
+(\( \log|K| \)) penalises over-flexible kernels (an "Occam" penalty); the
+second rewards kernels that explain the field well. We adjust the
+hyperparameters until the score is best.
 
 The **nugget** \( \eta \) is the important addition: a slice of pure noise the
 model may attribute to observation error rather than signal. Without it the
@@ -389,7 +390,7 @@ maximise the score over the three length-scales plus the nugget ratio, with
 est <- infer_kernel_params(obs_data, coordinates, nt = nt, period = period,
                            refine = TRUE)
 
-# did we recover the knobs we simulated from?
+# did we recover the hyperparameters we simulated from?
 data.frame(
   parameter = c("length_scale", "periodic_scale", "long_term_scale"),
   truth     = c(true_length_scale, true_periodic_scale, true_long_term_scale),


### PR DESCRIPTION
## What

Restructures the walkthrough vignette around its natural three-part arc and splits the Kronecker material into a dedicated article.

## Walkthrough restructure

The old numbered sections ran two numbering schemes at once and buried the fitting story. The new structure (subsections now in the TOC):

1. **The model** — the observation maths (counts by site and week), the kernels and their hyperparameters, then the simulated data with missingness.
2. **Fitting the kernel hyperparameters** — the plug-in field, marginal-likelihood scoring, the EM refinement for gaps, and the worked fit-and-check.
3. **From fitted kernels to predictions** — the best guess (posterior mean), then the interval (exact variance plus the gaps correction), then the worked predict-and-coverage check.

Each part closes with its worked example; caveats and references close the article. No content was dropped — everything was re-homed.

## New vignette: *The Kronecker trick*

Covers both identities behind weave's speed — the eigendecomposition route to the log-determinant/quadratic form (fitting, and the exact part of the prediction interval) and the matrix-free Kronecker product (the CG solves) — linked from the walkthrough, the gentle introduction, and the README.

The old single covariance heatmap is rebuilt as a three-step figure sequence the reader can follow: the 3×3 spatial kernel with its values printed (two close sites, one distant), the 8×8 banded temporal kernel, then the 24×24 product with site-labelled blocks and the faint site 1 × site 3 block outlined and annotated as 0.14 × the temporal kernel — tying it back to the number in the first panel. Rebuilding it also fixed two real bugs in the old figure: diagonal entries carry a tiny nugget above 1 and rendered grey, and the toy's `period = 8` produced a wrap-around correlation that contradicted the fades-with-lag caption.

## Terminology

Informal names for technical objects are gone — "knobs" for the hyperparameters, "turn the dial", "juggle" — replaced with plain, precise wording throughout. Explanatory analogies in the intuition boxes remain.

## Verification

- All touched vignettes (walkthrough, kronecker, gaussian-processes) knit cleanly
- Rendered heading tree matches the intended structure; all three new figures inspected as rendered output
- `pkgdown::check_pkgdown()` clean; README regenerated from README.Rmd

🤖 Generated with [Claude Code](https://claude.com/claude-code)
